### PR TITLE
ci: fix PR title check and issue template indentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,44 +3,44 @@ description: Report an issue of `@master/styles`
 labels: [bug]
 
 body:
-    - type: markdown
-      attributes:
-          value: Thanks for taking the time to make a bug report!
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to make a bug report!
 
-    - type: textarea
-      id: description
-      attributes:
-          label: Description
-          description: Please provide a detailed description to tell us what the bug is. Also tell us what is the expected behavior you think.
-          placeholder: When I am going to ... by using ..., the "..." error happens. ...
-      validations:
-          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a detailed description to tell us what the bug is. Also tell us what is the expected behavior you think.
+      placeholder: When I am going to ... by using ..., the "..." error happens. ...
+    validations:
+      required: true
 
-    - type: textarea
-      id: reproduction
-      attributes:
-          label: Reproduction
-          description: Please provide a step-by-step [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) of the bug. It helps us to efficiently track down the bug.
-          placeholder: |
-              1. ... 
-              2. ... 
-              3. ...
-      validations:
-          required: false
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a step-by-step [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) of the bug. It helps us to efficiently track down the bug.
+      placeholder: |
+        1. ... 
+        2. ... 
+        3. ...
+    validations:
+      required: false
 
-    - type: textarea
-      id: system
-      attributes:
-          label: System Informations
-          description: Please provide the system informations related to the bug. Browser, OS, Node.js, Package Manager ...
-          placeholder: |
-              Browser: Chrome 99.0.1234.56
-              OS: macOS 12.0.1 (amd64)
-              Node.js: 16.31.1
-              Package Manager: pnpm 6.32.3
-      validations:
-          required: true
+  - type: textarea
+    id: system
+    attributes:
+      label: System Informations
+      description: Please provide the system informations related to the bug. Browser, OS, Node.js, Package Manager ...
+      placeholder: |
+        Browser: Chrome 99.0.1234.56
+        OS: macOS 12.0.1 (amd64)
+        Node.js: 16.31.1
+        Package Manager: pnpm 6.32.3
+    validations:
+      required: true
 
-    - type: markdown
-      attributes:
-          value: Thank you for the bug report! We will try to investigate the bug as soon as possible.
+  - type: markdown
+    attributes:
+      value: Thank you for the bug report! We will try to investigate the bug as soon as possible.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-    - name: Questions & Discussions
-      url: https://github.com/master-co/styles/discussions
-      about: Use GitHub discussions for forum-like discussions and questions.
-    - name: Discord Chat
-      url: https://discord.gg/sZNKpAAAw6
-      about: A friendly chat room, where you can ask questions and get help from other users in real time.
+  - name: Questions & Discussions
+    url: https://github.com/master-co/styles/discussions
+    about: Use GitHub discussions for forum-like discussions and questions.
+  - name: Discord Chat
+    url: https://discord.gg/sZNKpAAAw6
+    about: A friendly chat room, where you can ask questions and get help from other users in real time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,16 +3,16 @@ description: Propose a new feature in `@master/styles`
 labels: [enhancement]
 
 body:
-    - type: markdown
-      attributes:
-          value: Have a great idea for a new feature? Let us know!
+  - type: markdown
+    attributes:
+      value: Have a great idea for a new feature? Let us know!
 
-    - type: textarea
-      id: description
-      attributes:
-          label: Description
-          description: |
-              Please tell us what you want to see in the next release and why you want to see it. 
-              If you are going to make a pull request, please let us know your scheduling.
-      validations:
-          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please tell us what you want to see in the next release and why you want to see it. 
+        If you are going to make a pull request, please let us know your scheduling.
+    validations:
+      required: true

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -1,6 +1,6 @@
 name: Checking title of pull request
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
- Fix PR title check by changing trigger to `pull_request_target`
  - Preventing security and permission issue, see https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
- Change indentation of issue template to 2 spaces
  - Same as the oldest `yaml` file in this repo ([.circleci/config.yml](https://github.com/master-co/css/tree/main/.circleci/config.yml))
  - Now all the `yaml` files in this repo are applied to 2 spaces indentation
  - I am sorry for making this mistake 2 month ago