### PR TITLE
feat: remSize for dynamic REM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_size = 4
+indent_style = space

--- a/src/style.ts
+++ b/src/style.ts
@@ -88,6 +88,7 @@ export class Style {
     static unit = REM;
     static colorful: boolean;
     static rootSize: number = 16;
+    static remSize: number;
     static readonly values: Record<string, any>;
     static readonly semantics: { [key: string]: any };
     static readonly breakpoints: { [key: string]: number };
@@ -161,8 +162,17 @@ export class Style {
                 return;
             }
         }
-        let { id, semantics, unit, colors, key, values, colorful, breakpoints, mediaQueries, colorSchemes, rootSize } = TargetStyle;
+        let { id, semantics, unit, colors, key, values, colorful, breakpoints, mediaQueries, colorSchemes, rootSize, remSize } = TargetStyle;
         let token = name;
+
+
+        if (remSize) {
+            const remToPxDefault = 16;
+            const remRatio = remSize / remToPxDefault;
+
+            document.documentElement.style.setProperty('font-size', `${remRatio * 100}%`);
+            document.body.style.setProperty('font-size', `${remRatio}rem`);
+        }
 
         // 防止非色彩 style 的 token 被解析
         if (!colorful) {


### PR DESCRIPTION
This resolves the issue highlighted on #49 as the prior PR relates to the rootSize of Master units, this PR introduces a new property: `remSize`  therefore avoiding any breaking changes.

`remSize` accepts a number, that is used to change the mapping from px to rem, i.e. when remSize is set to 10, `10rem` units represent `100px`, where as before it would've represented `160px`.

To also keep the browsers happy, this resets the body fontSize to `16px` (or 1 rem) automatically.

Additionally, to keep the IDE and linters happy, I've added an `.editorconfig`.