### PR TITLE
Fix: Group rules aren't correctly extracted

### DIFF
--- a/packages/compiler/src/options/extract.ts
+++ b/packages/compiler/src/options/extract.ts
@@ -52,7 +52,7 @@ const peelString = (content) => {
 
 const checkToExclude = (content, css: MasterCSS) => {
     return !content
-        || (!content.match(/(?:^[\w-]+:[\w$#]+)|(?:^[@~][\w-]+$)/) && !Object.keys(css.config.semantics ?? semantics).includes(content))
+        || (!content.match(/(?:^\{?[\w-]+:[\w$#]+)|(?:^[@~][\w-]+$)/) && !Object.keys(css.config.semantics ?? semantics).includes(content))
         || content.match(/\*\*/)
         || content.match(/:\[/)
         || content.match(/\$\{/)


### PR DESCRIPTION
changed regexp to include group styles during compiler extraction to fix #87 