### PR TITLE
Feat: `screen` shortcut for `100vh` and `100vw`

### DIFF
--- a/packages/css/src/config/values.ts
+++ b/packages/css/src/config/values.ts
@@ -12,11 +12,15 @@ const contentExtrema = {
 }
 
 const heightScreen = {
-    screen: '100vh'
+    vp: '100vh',
+    vport: '100vh',
+    viewport: '100vh'
 }
 
 const widthScreen = {
-    screen: '100vw'
+    vp: '100vw',
+    vport: '100vw',
+    viewport: '100vw
 }
 
 const sizingValues = {

--- a/packages/css/src/config/values.ts
+++ b/packages/css/src/config/values.ts
@@ -11,6 +11,14 @@ const contentExtrema = {
     max: 'max-content'
 }
 
+const heightScreen = {
+    screen: '100vh'
+}
+
+const widthScreen = {
+    screen: '100vw'
+}
+
 const sizingValues = {
     full: '100%',
     fit: 'fit-content',
@@ -77,12 +85,12 @@ const values = {
         stroke: 'stroke-box',
         view: 'view-box'
     },
-    Width: sizingValues,
-    MinWidth: sizingValues,
-    MinHeight: sizingValues,
-    MaxWidth: sizingValues,
-    MaxHeight: sizingValues,
-    Height: sizingValues,
+    Width: {...sizingValues, ...widthScreen},
+    MinWidth: {...sizingValues, ...widthScreen},
+    MinHeight: {...sizingValues, ...heightScreen},
+    MaxWidth: {...sizingValues, ...widthScreen},
+    MaxHeight: {...sizingValues, ...heightScreen},
+    Height: {...sizingValues, ...heightScreen},
     FlexBasis: sizingValues
 }
 

--- a/packages/language-service/server/src/constant.ts
+++ b/packages/language-service/server/src/constant.ts
@@ -798,32 +798,32 @@ export const masterCssKeyValues: MasterCssKey[] = [
     {
         key: ['width', 'w'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'vp', 'vport', 'viewport']
     },
     {
         key: ['min-width', 'min-w'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'vp', 'vport', 'viewport']
     },
     {
         key: ['max-width', 'max-w'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'vp', 'vport', 'viewport']
     },
     {
         key: ['height', 'h'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'vp', 'vport', 'viewport']
     },
     {
         key: ['min-height', 'min-h'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'vp', 'vport', 'viewport']
     },
     {
         key: ['max-height', 'max-h'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'vp', 'vport', 'viewport']
     },
     //TYPOGRAPHY
     {

--- a/packages/language-service/server/src/constant.ts
+++ b/packages/language-service/server/src/constant.ts
@@ -798,32 +798,32 @@ export const masterCssKeyValues: MasterCssKey[] = [
     {
         key: ['width', 'w'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
     },
     {
         key: ['min-width', 'min-w'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
     },
     {
         key: ['max-width', 'max-w'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
     },
     {
         key: ['height', 'h'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
     },
     {
         key: ['min-height', 'min-h'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
     },
     {
         key: ['max-height', 'max-h'],
         colorful: false,
-        values: ['100%', 'fit-content', 'max-content', 'min-content']
+        values: ['100%', 'fit-content', 'max-content', 'min-content', 'screen']
     },
     //TYPOGRAPHY
     {


### PR DESCRIPTION
Enables new classes for sizing.

`w:screen` as equivalent to `w:100vw`, 
`h:screen` as equivalent to `h:100vh` 

and so on for: 

- `width`, 
- `height`, 
- `min-width`, 
- `min-w`,
- `max-width`, 
- `max-w`,
- `min-height`, 
- `min-h`,
- `max-height`, 
- `max-h`.

Btw. Happy New Year! 🎉