### PR TITLE
Allow explicitly specifying entryId when multiple entries exist

### DIFF
--- a/packages/vite/src/core.ts
+++ b/packages/vite/src/core.ts
@@ -37,7 +37,12 @@ export default function masterCSS(options?: PluginOptions): Plugin[] {
             enforce: 'pre',
             configResolved(config) {
                 context.config = config
-                context.entryId = fg.sync(ENTRY_MODULE_PATTERNS, { cwd: config.root, absolute: true, onlyFiles: true, caseSensitiveMatch: false })[0]
+                context.entryId = options.entryId ?? fg.sync(ENTRY_MODULE_PATTERNS, {
+                    cwd: config.root,
+                    absolute: true,
+                    onlyFiles: true,
+                    caseSensitiveMatch: false
+                )[0]
                 if (process.env.DEBUG) {
                     console.log(`[@master/css.vite] mode: ${options.mode}`)
                     console.log(`[@master/css.vite] entry: ${context.entryId || 'none'}`)

--- a/packages/vite/src/options.ts
+++ b/packages/vite/src/options.ts
@@ -60,4 +60,9 @@ export interface PluginOptions {
      * Useful in Runtime
      */
     avoidFOUC?: boolean
+
+    /**
+     * Specifies which entry to use when multiple entries (i.e. main.tsx and index.ts) are present.
+     */
+    entryId?: string
 }


### PR DESCRIPTION
## Problem
In Vite projects where both `src/main.tsx` (used for vite serve) and `src/index.ts` (used for vite build) exist, the MasterCSS Vite plugin currently always picks `src/index.ts` as the entry due to glob ordering (alphabetical by default).

## Solution
This PR introduces a new `entryId` option for the `masterCSS()` plugin. It allows users to explicitly define the desired entry point:

```ts
masterCSS({
  entryId: process.env.NODE_ENV === 'production' 
    ? 'src/index.ts' 
    : 'src/main.tsx',
})
```
## Usage
No breaking changes. If `entryId` is not provided, the plugin behavior remains unchanged.