### PR TITLE
Fix(LanguageServer): Missing mcss-language-server binary entry

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -44,6 +44,10 @@
             "require": "./dist/index.cjs"
         }
     },
+    "bin": {
+        "mcss-language-server": "./dist/bin/index.cjs",
+        "master-css-language-server": "./dist/bin/index.cjs"
+    },
     "files": [
         "dist"
     ],

--- a/packages/language-server/src/bin/index.ts
+++ b/packages/language-server/src/bin/index.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+// Use the CJS build: the ESM build of this server re-exports through nested
+// dependency subpaths (`vscode-languageserver/node`,
+// `vscode-css-languageservice/lib/umd/...`) that have no `exports` map and
+// therefore fail Node ≥ 22 ESM resolution. CJS `require` is forgiving here
+// and is what every LSP host (VSCode, Neovim, Helix, Sublime) ends up
+// spawning anyway. techor compiles this file to `dist/bin/index.cjs`.
+import CSSLanguageServer from '../core'
+
+new CSSLanguageServer().start()

--- a/packages/language-server/tests/bin.test.ts
+++ b/packages/language-server/tests/bin.test.ts
@@ -1,0 +1,66 @@
+import { readFile, stat } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { describe, test, expect } from 'vitest'
+
+const pkgRoot = resolve(__dirname, '..')
+const builtBin = resolve(pkgRoot, 'dist/bin/index.cjs')
+
+describe('bin', () => {
+    test('package.json declares mcss-language-server bin pointing at the built script', async () => {
+        const pkg = JSON.parse(await readFile(resolve(pkgRoot, 'package.json'), 'utf8'))
+        expect(pkg.bin).toBeDefined()
+        expect(pkg.bin['mcss-language-server']).toBe('./dist/bin/index.cjs')
+        expect(pkg.bin['master-css-language-server']).toBe('./dist/bin/index.cjs')
+    })
+
+    test('bin source has node shebang and starts CSSLanguageServer', async () => {
+        const src = await readFile(resolve(pkgRoot, 'src/bin/index.ts'), 'utf8')
+        expect(src.startsWith('#!/usr/bin/env node')).toBe(true)
+        expect(src).toMatch(/CSSLanguageServer/)
+        expect(src).toMatch(/\.start\(\)/)
+    })
+
+    test.skipIf(!existsSync(builtBin))(
+        'built bin file is executable and responds to LSP initialize',
+        async () => {
+            // Permission bit
+            const st = await stat(builtBin)
+            // S_IXUSR = 0o100
+            expect((st.mode & 0o100) !== 0).toBe(true)
+
+            // Spawn the bin and send a real LSP initialize request.
+            const child = spawn('node', [builtBin, '--stdio'])
+            const msg = JSON.stringify({
+                jsonrpc: '2.0', id: 1, method: 'initialize',
+                params: { rootUri: null, workspaceFolders: [], capabilities: {} }
+            })
+            child.stdin.write(`Content-Length: ${Buffer.byteLength(msg)}\r\n\r\n${msg}`)
+
+            const got = await new Promise<string>((resolveOut, reject) => {
+                let buf = ''
+                let stderr = ''
+                const t = setTimeout(() => {
+                    child.kill()
+                    reject(new Error(`Timeout. stdout: ${buf.slice(0, 200)}, stderr: ${stderr.slice(0, 200)}`))
+                }, 6000)
+                child.stdout.on('data', (d) => {
+                    buf += d.toString()
+                    if (buf.includes('capabilities')) {
+                        clearTimeout(t)
+                        child.kill()
+                        resolveOut(buf)
+                    }
+                })
+                child.stderr.on('data', (d) => { stderr += d.toString() })
+                child.on('error', reject)
+            })
+
+            expect(got).toMatch(/Content-Length:/)
+            expect(got).toMatch(/"jsonrpc":"2\.0","id":1/)
+            expect(got).toMatch(/"capabilities":/)
+        },
+        15000
+    )
+})


### PR DESCRIPTION
## Summary

Closes #313. The `@master/css-language-server` package had no executable binary entry — `pnpm install -g @master/css-language-server` produced nothing in the global bin directory, so non-VSCode LSP hosts (Neovim, Helix, Sublime) couldn't spawn it.

## Changes

- Added `src/bin/index.ts` (CJS shim that requires the built `core` and calls `new CSSLanguageServer().start()`)
- Added `bin` field to `package.json`: `mcss-language-server` and `master-css-language-server` both point to `./dist/bin/index.cjs`
- Updated `css-docs/modules/language-server.md` with a "Standalone binary" section

## Why CJS, not ESM

The existing ESM build of this server re-exports through nested dependency subpaths (`vscode-languageserver/node`, `vscode-css-languageservice/lib/umd/...`) that have no \`exports\` map and therefore fail Node ≥ 22 ESM resolution. CJS \`require\` is forgiving and is what every LSP host ends up spawning anyway.

## Testing

- Real spawn test in \`tests/bin.test.ts\`: spawns the built bin, sends an LSP \`initialize\` JSON-RPC, asserts a \`capabilities\` reply
- All 9 \`@master/css-language-server\` test files pass
- Verified locally: \`pnpm install -g\` followed by \`mcss-language-server --stdio\` returns Content-Length-framed JSON-RPC reply with \`textDocumentSync\`, \`completionProvider\`, etc.