### PR TITLE
Add(Site): Generate llms.txt for LLM discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ packages/nuxt/playground/.output
 **/blob-report/
 **/playwright/.cache/
 **/.svelte-kit
+
+# generated llms.txt indexes (regenerated at build time)
+site/public/llms.txt
+site/public/llms-full.txt

--- a/site/package.json
+++ b/site/package.json
@@ -5,10 +5,12 @@
     "scripts": {
         "prepare-app": "tsx --env-file=.env ./prepare",
         "dev": "pnpm prepare-app && next dev --turbo",
-        "build": "pnpm prepare-app && pnpm build:repo && pnpm build:next && pnpm build:css",
+        "build": "pnpm prepare-app && pnpm build:llms && pnpm build:repo && pnpm build:next && pnpm build:css",
         "build:repo": "cd ../ && pnpm build && cd site",
         "build:next": "cross-env NODE_OPTIONS=--max-old-space-size=16384 next build --turbo",
         "build:css": "node ../packages/cli/dist/bin/index.mjs render \".next/**/*.html\"",
+        "build:llms": "tsx scripts/generate-llms-txt.ts",
+        "test:llms": "tsx --test scripts/generate-llms-txt.test.ts",
         "start": "next start",
         "lint": "next lint",
         "type-check": "tsc --noEmit"

--- a/site/scripts/generate-llms-txt.test.ts
+++ b/site/scripts/generate-llms-txt.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+    deriveTitle,
+    pageUrl,
+    topSection,
+    renderLlmsIndex,
+    renderLlmsFull,
+    type Page
+} from './generate-llms-txt.ts'
+
+const fixture: Page[] = [
+    {
+        file: '/x/guide/content.mdx',
+        section: 'guide',
+        url: '/en/guide',
+        title: 'Guide',
+        body: '## Getting Started\nIntro.'
+    },
+    {
+        file: '/x/guide/colors/content.mdx',
+        section: 'guide',
+        url: '/en/guide/colors',
+        title: 'Colors',
+        body: '# Colors\nColor system overview.'
+    },
+    {
+        file: '/x/reference/content.mdx',
+        section: 'reference',
+        url: '/en/reference',
+        title: 'Reference',
+        body: '# Reference\nAPI reference.'
+    }
+]
+
+test('deriveTitle prefers the first heading over the route segment', () => {
+    assert.equal(deriveTitle('# Hello World\nrest', 'fallback'), 'Hello World')
+    assert.equal(deriveTitle('## Subhead\nbody', 'fallback'), 'Subhead')
+})
+
+test('deriveTitle strips trailing [sr-only] / {.cls} markers from MDX headings', () => {
+    assert.equal(deriveTitle('## Overview [sr-only]\nbody', 'fallback'), 'Overview')
+    assert.equal(deriveTitle('## Overview {.sr-only}\nbody', 'fallback'), 'Overview')
+})
+
+test('deriveTitle falls back to titleized last segment when no heading', () => {
+    assert.equal(deriveTitle('no headings here', 'static-extraction'), 'Static Extraction')
+})
+
+test('pageUrl strips content.mdx and prefixes locale', () => {
+    assert.equal(pageUrl('guide/colors/content.mdx'), '/en/guide/colors')
+    assert.equal(pageUrl('guide/content.mdx', 'tw'), '/tw/guide')
+})
+
+test('topSection extracts the first segment', () => {
+    assert.equal(topSection('guide/colors/content.mdx'), 'guide')
+    assert.equal(topSection('reference/content.mdx'), 'reference')
+})
+
+test('renderLlmsIndex emits H1 + summary + per-section H2 with links', () => {
+    const out = renderLlmsIndex(fixture, 'https://example.test')
+    assert.match(out, /^# Master CSS\n/)
+    assert.match(out, /\n> .+\n/)
+    assert.match(out, /\n## Guide\n/)
+    assert.match(out, /\n## Reference\n/)
+    assert.match(out, /- \[Guide\]\(https:\/\/example\.test\/en\/guide\)/)
+    assert.match(out, /- \[Colors\]\(https:\/\/example\.test\/en\/guide\/colors\)/)
+    assert.match(out, /- \[Reference\]\(https:\/\/example\.test\/en\/reference\)/)
+})
+
+test('renderLlmsIndex sorts sections alphabetically and pages by url', () => {
+    const out = renderLlmsIndex(fixture)
+    const guideIdx = out.indexOf('## Guide')
+    const refIdx = out.indexOf('## Reference')
+    assert.ok(guideIdx > 0 && refIdx > guideIdx)
+    const colorsIdx = out.indexOf('Colors')
+    const guideTopIdx = out.indexOf('](https://rc.css.master.co/en/guide)')
+    assert.ok(guideTopIdx > 0 && guideTopIdx < colorsIdx)
+})
+
+test('renderLlmsFull concatenates each page body with a Source line', () => {
+    const out = renderLlmsFull(fixture, 'https://example.test')
+    assert.match(out, /Source: https:\/\/example\.test\/en\/guide\b/)
+    assert.match(out, /Color system overview\./)
+    assert.match(out, /API reference\./)
+})

--- a/site/scripts/generate-llms-txt.ts
+++ b/site/scripts/generate-llms-txt.ts
@@ -1,0 +1,139 @@
+import { readFile, writeFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_LOCALE = 'en'
+const SITE_URL = 'https://rc.css.master.co'
+const PROJECT_NAME = 'Master CSS'
+const PROJECT_DESC =
+    'A CSS language and framework for rapidly building beautiful websites and design systems with rule-based CSS-in-class.'
+
+export type Page = {
+    /** Filesystem path of the .mdx file. */
+    file: string
+    /** Top-level URL section, e.g. "guide". */
+    section: string
+    /** Public URL path, e.g. "/en/guide/colors". */
+    url: string
+    /** Display title (from first H1/H2 or last route segment). */
+    title: string
+    /** Raw MDX body. */
+    body: string
+}
+
+const TITLE_FROM_HEADING = /^#{1,2}\s+(.+?)\s*$/m
+const HEADING_TRAILING_TAG = /\s*[\[\{][^\]\}]*[\]\}]\s*$/
+
+export function deriveTitle(body: string, fallbackSegment: string): string {
+    const m = body.match(TITLE_FROM_HEADING)
+    if (m) return m[1].replace(HEADING_TRAILING_TAG, '').trim()
+    return fallbackSegment
+        .split('-')
+        .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+        .join(' ')
+}
+
+/** Convert filesystem path under app/[locale]/ into a public URL path. */
+export function pageUrl(relPath: string, locale = DEFAULT_LOCALE): string {
+    // relPath is like "guide/colors/content.mdx"
+    const dir = relPath.replace(/\/content\.mdx$/, '')
+    return `/${locale}${dir ? '/' + dir : ''}`
+}
+
+export function topSection(relPath: string): string {
+    return relPath.split('/')[0] ?? ''
+}
+
+export function renderLlmsIndex(pages: Page[], siteUrl = SITE_URL): string {
+    const bySection = new Map<string, Page[]>()
+    for (const p of pages) {
+        if (!bySection.has(p.section)) bySection.set(p.section, [])
+        bySection.get(p.section)!.push(p)
+    }
+    const sortedSections = [...bySection.keys()].sort()
+
+    const lines: string[] = []
+    lines.push(`# ${PROJECT_NAME}`, '')
+    lines.push(`> ${PROJECT_DESC}`, '')
+    for (const sec of sortedSections) {
+        const items = bySection.get(sec)!.sort((a, b) => a.url.localeCompare(b.url))
+        lines.push(`## ${sec.charAt(0).toUpperCase() + sec.slice(1)}`)
+        for (const p of items) {
+            lines.push(`- [${p.title}](${siteUrl}${p.url})`)
+        }
+        lines.push('')
+    }
+    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+}
+
+export function renderLlmsFull(pages: Page[], siteUrl = SITE_URL): string {
+    const sorted = [...pages].sort((a, b) => a.url.localeCompare(b.url))
+    const out: string[] = [`# ${PROJECT_NAME}`, '', `> ${PROJECT_DESC}`, '']
+    for (const p of sorted) {
+        out.push('---', '')
+        out.push(`# ${p.title}`, '')
+        out.push(`Source: ${siteUrl}${p.url}`, '')
+        out.push(p.body.trim(), '')
+    }
+    return out.join('\n').trimEnd() + '\n'
+}
+
+async function listMdx(root: string): Promise<string[]> {
+    const out: string[] = []
+    async function walk(dir: string) {
+        const entries = await readdir(dir, { withFileTypes: true })
+        for (const e of entries) {
+            const full = path.join(dir, e.name)
+            if (e.isDirectory()) await walk(full)
+            else if (e.isFile() && e.name === 'content.mdx') out.push(full)
+        }
+    }
+    await walk(root)
+    return out
+}
+
+export async function loadPages(localeRoot: string): Promise<Page[]> {
+    const files = await listMdx(localeRoot)
+    const pages: Page[] = []
+    for (const file of files) {
+        const rel = path.relative(localeRoot, file).split(path.sep).join('/')
+        const body = await readFile(file, 'utf8')
+        const segments = rel.replace(/\/content\.mdx$/, '').split('/')
+        const lastSegment = segments[segments.length - 1] ?? ''
+        pages.push({
+            file,
+            section: topSection(rel),
+            url: pageUrl(rel),
+            title: deriveTitle(body, lastSegment),
+            body
+        })
+    }
+    return pages
+}
+
+export async function generate(siteRoot: string): Promise<{ index: string; full: string }> {
+    const localeRoot = path.join(siteRoot, 'app', `[${'locale'}]`)
+    const pages = await loadPages(localeRoot)
+    const index = renderLlmsIndex(pages)
+    const full = renderLlmsFull(pages)
+    const publicDir = path.join(siteRoot, 'public')
+    await writeFile(path.join(publicDir, 'llms.txt'), index, 'utf8')
+    await writeFile(path.join(publicDir, 'llms-full.txt'), full, 'utf8')
+    return { index, full }
+}
+
+const isMain = (() => {
+    if (typeof process === 'undefined' || !process.argv[1]) return false
+    try {
+        return path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+    } catch {
+        return false
+    }
+})()
+
+if (isMain) {
+    const siteRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..')
+    const { index } = await generate(siteRoot)
+    const lineCount = index.split('\n').length
+    console.log(`[llms.txt] generated index (${lineCount} lines) + full at ${path.join(siteRoot, 'public')}`)
+}


### PR DESCRIPTION
Closes #386.

## Summary

Adds a build-time generator that walks every \`app/[locale]/**/content.mdx\` and emits two files in \`public/\`:

- \`llms.txt\` — sectioned index per the llmstxt.org spec, ~280 lines
- \`llms-full.txt\` — full-content concatenation, ~13K lines

\`pnpm build:llms\` is wired into the existing \`pnpm build\` chain. Output files are gitignored (regenerated on every build).

## Changes

- \`site/scripts/generate-llms-txt.ts\` — generator with pure helpers (\`deriveTitle\`, \`pageUrl\`, \`renderLlmsIndex\`, \`renderLlmsFull\`)
- \`site/scripts/generate-llms-txt.test.ts\` — 8 Node-native test cases (heading extraction, sr-only stripping, route construction, sorted output, full concat)
- \`site/package.json\` — \`build:llms\` + \`test:llms\` scripts
- \`.gitignore\` — exclude generated output
- \`css-docs/internal-and-website.md\` — documents the new build step

## Testing

- 8/8 Node tests pass via \`tsx --test\`
- Real run on actual site content produces 280-line index + 13271-line full output, valid llms.txt format, no \`[sr-only]\` MDX directives leak into titles