### PR TITLE
Fix(CSS): Inline @<mode> variable keys + alpha alias to mode-only variables

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -420,8 +420,13 @@ export default class MasterCSS {
                             addVariable(newVariable.name, newVariable, mode)
                             if (aliasVariable.modes) {
                                 for (const eachMode in aliasVariable.modes) {
-                                    const aliasModeVariable = aliasVariable.modes[eachMode]
-                                    addVariable(newVariable.name, aliasModeVariable as Variable, eachMode)
+                                    const aliasModeVariable = aliasVariable.modes[eachMode] as any
+                                    const newAliasModeVariable: any = { ...aliasModeVariable }
+                                    if (alpha) {
+                                        const newModeAlpha = Number(alpha) * (aliasModeVariable.alpha ?? 1)
+                                        if (newModeAlpha < 1) newAliasModeVariable.alpha = newModeAlpha
+                                    }
+                                    addVariable(newVariable.name, newAliasModeVariable as Variable, eachMode)
                                 }
                             }
                         }

--- a/packages/core/src/utils/extend-config.ts
+++ b/packages/core/src/utils/extend-config.ts
@@ -52,21 +52,32 @@ export default function extendConfig(...configs: (Config | undefined)[]) {
         const isExtended = '__extended' in rest
         if (isExtended) delete rest.__extended
 
-        // variables
+        // variables — also extracts inline `@<mode>` entries into a modes accumulator
+        const inlineModes: Record<string, Record<string, Variable>> = {}
         if (variables) {
             extendedConfig.variables ??= {}
-            const flattened = isExtended ? { ...variables } : flattenMetaObject(variables, [], {})
+            const flattened = isExtended
+                ? { ...variables }
+                : flattenMetaObject(variables, [], {}, inlineModes as any)
             Object.assign(extendedConfig.variables, flattened)
         }
 
         // modes
-        if (modes) {
+        if (modes || Object.keys(inlineModes).length > 0) {
             extendedConfig.modes ??= {}
-            for (const [modeName, modeVars] of Object.entries(modes)) {
-                const flattenedMode = isExtended ? { ...modeVars } : flattenMetaObject(modeVars, [], {})
+            if (modes) {
+                for (const [modeName, modeVars] of Object.entries(modes)) {
+                    const flattenedMode = isExtended ? { ...modeVars } : flattenMetaObject(modeVars, [], {})
+                    extendedConfig.modes[modeName] = {
+                        ...extendedConfig.modes[modeName],
+                        ...flattenedMode
+                    }
+                }
+            }
+            for (const [modeName, modeVars] of Object.entries(inlineModes)) {
                 extendedConfig.modes[modeName] = {
                     ...extendedConfig.modes[modeName],
-                    ...flattenedMode
+                    ...modeVars
                 }
             }
         }

--- a/packages/core/src/utils/flatten-meta-object.ts
+++ b/packages/core/src/utils/flatten-meta-object.ts
@@ -1,12 +1,38 @@
+type FlatVariable = {
+    name: string
+    value: any
+    key: string
+    group?: string
+    namespace?: string
+}
+
 export default function flattenMetaObject(
     obj: Record<string, any>,
     name: string[] = [],
-    result: Record<
-        string,
-        { name: string; value: any; key: string; group?: string; namespace?: string }
-    > = {}
+    result: Record<string, FlatVariable> = {},
+    modes: Record<string, Record<string, FlatVariable>> = {}
 ) {
     for (const [rawKey, rawValue] of Object.entries(obj)) {
+        // Inline mode marker: keys starting with '@' (e.g. '@light', '@dark')
+        // route the value into the modes accumulator under the parent path,
+        // instead of producing a literal `<parent>-@<mode>` flat variable.
+        if (rawKey.startsWith('@') && name.length > 0) {
+            const modeName = rawKey.slice(1)
+            const parentFlatKey = name.join('-')
+            const parentKey = name[name.length - 1]
+            const parentGroup = name.slice(0, -1).join('.')
+            const parentNamespace = name[0]
+            modes[modeName] ??= {}
+            modes[modeName][parentFlatKey] = {
+                name: parentFlatKey,
+                key: parentKey,
+                value: Array.isArray(rawValue) ? rawValue.join(',') : rawValue,
+                group: name.length > 1 ? parentGroup : undefined,
+                namespace: name.length > 1 ? parentNamespace : undefined,
+            }
+            continue
+        }
+
         const key = rawKey || name[0] || ''
         const path = [...name, rawKey].filter(Boolean)
         const flatKey = path.join('-')
@@ -33,7 +59,7 @@ export default function flattenMetaObject(
                 namespace: path.length > 1 ? namespace : undefined,
             }
         } else {
-            flattenMetaObject(rawValue, path, result)
+            flattenMetaObject(rawValue, path, result, modes)
         }
     }
 

--- a/packages/core/tests/issue-356-repro.test.ts
+++ b/packages/core/tests/issue-356-repro.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'vitest'
+import { MasterCSS } from '../src'
+
+describe('issue #356: alpha alias on a variable that itself has @light/@dark modes', () => {
+    const buildConfig = () => ({
+        variables: {
+            color: {
+                brand: '#4285f4',
+                brandDark: '#3266cc',
+                base: {
+                    '@light': '$(color-brand)',
+                    '@dark': '$(color-brandDark)'
+                },
+                soft: '$(color-base)/.2',
+                softer: '$(color-base)/.15',
+                softest: '$(color-base)/.1'
+            }
+        },
+        rules: {
+            bg: { match: '^bg:', layer: 'general', declarations: { 'background-color': '$0' } }
+        }
+    })
+
+    test('constructor does not throw with inline @<mode> keys (regression for original crash)', () => {
+        expect(() => new MasterCSS(buildConfig())).not.toThrow()
+    })
+
+    test('inline @<mode> keys produce a base variable with light + dark modes', () => {
+        const css = new MasterCSS(buildConfig())
+        const v = css.variables.get('color-base') as any
+        expect(v).toBeDefined()
+        expect(v.type).toBe('color')
+        expect(v.modes && Object.keys(v.modes).sort()).toEqual(['dark', 'light'])
+        expect(v.modes.light?.value).toBeTruthy()
+        expect(v.modes.dark?.value).toBeTruthy()
+    })
+
+    test('alpha alias /.2 propagates the alpha to every mode of the aliased variable', () => {
+        const css = new MasterCSS(buildConfig())
+        const v = css.variables.get('color-soft') as any
+        expect(v).toBeDefined()
+        expect(v.type).toBe('color')
+        expect(v.modes?.light?.alpha).toBe(0.2)
+        expect(v.modes?.dark?.alpha).toBe(0.2)
+    })
+
+    test('chained alpha aliases (.15, .1) keep correct alpha per mode', () => {
+        const css = new MasterCSS(buildConfig())
+        const softer = css.variables.get('color-softer') as any
+        const softest = css.variables.get('color-softest') as any
+        expect(softer.modes?.light?.alpha).toBe(0.15)
+        expect(softer.modes?.dark?.alpha).toBe(0.15)
+        expect(softest.modes?.light?.alpha).toBe(0.1)
+        expect(softest.modes?.dark?.alpha).toBe(0.1)
+    })
+})


### PR DESCRIPTION
Closes #356.

## Summary

Two coupled bugs in variable resolution surfaced by the issue's repro:

1. \`flatten-meta-object.ts\` didn't recognize \`@<mode>\` keys (e.g. \`{neutral: {'@light': '\$(slate-60)', '@dark': '\$(gray-30)'}}\`) — they were treated as nested keys, so a variable like \`color-line-neutral-@light\` showed up instead of \`color-line-neutral\` with two modes.
2. When an alpha alias (\`'\$(color-base)/.2'\`) targeted a mode-only variable, the alpha was dropped from the per-mode entries.

## Changes

- \`flatten-meta-object.ts\` — \`@<mode>\` keys now route into a shared \`modes\` accumulator instead of producing literal-pipe flat keys
- \`extend-config.ts\` — merges the inline modes into \`extendedConfig.modes\`
- \`core.ts:resolveVariables\` — alpha alias now applies to each mode entry, not just the root
- New regression test \`tests/issue-356-repro.test.ts\` (4 cases, alpha precise to 0.2 / 0.15 / 0.1)

## Testing

- 4/4 new tests pass; all 109 core test files still pass
- Verified end-to-end via \`examples/blank\` + \`agent-browser\`: \`bg:soft\` with \`color.base.@light = \$(color-brand)\` and \`color.soft = \$(color-base)/.2\` produces \`rgba(66,133,244,0.2)\` in light mode and \`rgba(50,102,204,0.2)\` in dark mode
- Updated \`css-docs/modules/core.md\` with an "Inline @<mode> 語法" section

Follow-up commit \`a68275552\` removed \`null\` base-config arg in tests so \`tsc --noEmit\` passes.