### PR TITLE
Fix(Extractor): $name:value classes dropped by needExclude regex

### DIFF
--- a/packages/extractor/src/functions/extract-latent-classes.ts
+++ b/packages/extractor/src/functions/extract-latent-classes.ts
@@ -123,7 +123,7 @@ const checkToExclude = (content: string) => {
 const needExclude = (content: string) => {
     return !content
         || (
-            !content.match(/(?:\S*\{\S*\})|(?:^[\w\-()]+:\S+)|(?:^[\w-]+\(\S+\))|(?:^[@~]\S+$)|(?:^[\w-]+)/)
+            !content.match(/(?:\S*\{\S*\})|(?:^[$\w\-()]+:\S+)|(?:^[\w-]+\(\S+\))|(?:^[@~]\S+$)|(?:^[\w-]+)/)
             && !content.match(/^(?:calc\(.*\)|\d+(?:%|cm|mm|q|in|pt|pc|px|em|rem|ex|rex|cap|rcap|ch|rch|ic|ric|lh|rlh|vw|svw|lvw|dvw|vh|svh|lvh|dvh|vi|svi|lvi|dvi|vb|svb|lvb|dvb|vmin|svmin|lvmin|dvmin|vmax|svmax|lvmax|dvmax|cqw|cqh|cqi|cqb|cqmin|cqmax|deg|grad|rad|turn|s|ms|hz|khz|dpi|dpcm|dppx|x|fr|db|st)?)x(?:calc\(.*\)|\d+(?:%|cm|mm|q|in|pt|pc|px|em|rem|ex|rex|cap|rcap|ch|rch|ic|ric|lh|rlh|vw|svw|lvw|dvw|vh|svh|lvh|dvh|vi|svi|lvi|dvi|vb|svb|lvb|dvb|vmin|svmin|lvmin|dvmin|vmax|svmax|lvmax|dvmax|cqw|cqh|cqi|cqb|cqmin|cqmax|deg|grad|rad|turn|s|ms|hz|khz|dpi|dpcm|dppx|x|fr|db|st)?)$/)
         )
         || content.match(/\*\*/)

--- a/packages/extractor/tests/issue-337-variable-class.test.ts
+++ b/packages/extractor/tests/issue-337-variable-class.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from 'vitest'
+import { extractLatentClasses } from '../src'
+
+test('issue #337: extracts $name:$(custom-var) class from source', () => {
+    const content = `<div class="$test:$(test-color) bg:white">x</div>`
+    expect(extractLatentClasses(content)).toContain('$test:$(test-color)')
+})
+
+test('issue #337: extracts $name:$(custom-var) when standalone in attribute', () => {
+    const content = `<div class="$test:$(test-color)">x</div>`
+    expect(extractLatentClasses(content)).toContain('$test:$(test-color)')
+})
+
+test('issue #337: extracts $name:$(custom-var) from JS classList.add', () => {
+    const content = `el.classList.add('$test:$(test-color)')`
+    expect(extractLatentClasses(content)).toContain('$test:$(test-color)')
+})


### PR DESCRIPTION
Closes #337.

## Summary

Static extraction silently dropped classes like \`\$test:\$(test-color)\`. The lead-character regex in \`needExclude\` (\`^[\\w\\-()]+:\\S+\`) didn't include \`\$\`, so any class starting with \`\$\` failed every alternative and was treated as not-a-class.

## Changes

- \`packages/extractor/src/functions/extract-latent-classes.ts\` — single regex change: \`[\\w\\-()]\` → \`[\$\\w\\-()]\` in the keep-alternation
- New \`tests/issue-337-variable-class.test.ts\` — 3 cases (HTML class attr, JS \`classList.add\`, standalone)

## Testing

- 3/3 new tests pass; all 9 extractor test files still pass
- Blast radius is one character in one regex, only affects what \`needExclude\` keeps vs drops