### PR TITLE
Fix(CSS): {prop:val|val} group declarations render literal pipe

### DIFF
--- a/packages/core/src/declarers/core.group.ts
+++ b/packages/core/src/declarers/core.group.ts
@@ -8,7 +8,11 @@ export default function coreGroup(this: SyntaxRule, value: string) {
         const indexOfColon = propertyName.indexOf(':')
         if (indexOfColon !== -1) {
             const propName = propertyName.slice(0, indexOfColon)
-            declarations[propName] = propertyName.slice(indexOfColon + 1)
+            // `|` is the class-name-safe space separator (used because spaces
+            // would break HTML class attribute parsing). Inside `{ … }` group
+            // values the literal pipe must be expanded back to a space, otherwise
+            // the browser sees `paint-order:stroke|fill` and rejects the rule.
+            declarations[propName] = propertyName.slice(indexOfColon + 1).replace(/\|/g, ' ')
         }
     }
     const handleRule = (rule: SyntaxRule) => {

--- a/packages/core/tests/issue-363-fallback.test.ts
+++ b/packages/core/tests/issue-363-fallback.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest'
+import { MasterCSS, config as defaultConfig } from '../src'
+
+describe('issue #363: `|` separator inside `{...}` groups', () => {
+    test('{paint-order:stroke|fill} expands `|` to space inside group', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('{paint-order:stroke|fill}')
+        expect(rule?.text).toContain('paint-order:stroke fill')
+        expect(rule?.text).not.toContain('paint-order:stroke|fill')
+    })
+
+    test('{paint-order:stroke} single value still works (regression)', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        expect(css.create('{paint-order:stroke}')?.text).toContain('paint-order:stroke')
+    })
+
+    test('regular bg:white|red still treats `|` as space (regression)', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('bg:white|red')
+        // bg expects multi-token; `|` is a class-safe space
+        expect(rule?.text).toBeTruthy()
+        // `|` may legitimately appear in the escaped class selector, but never in declarations
+        const declStart = rule!.text.indexOf('{')
+        expect(rule!.text.slice(declStart)).not.toContain('|')
+    })
+
+    test('three-value list works in group', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        expect(css.create('{paint-order:stroke|fill|markers}')?.text)
+            .toContain('paint-order:stroke fill markers')
+    })
+})


### PR DESCRIPTION
Closes #363.

## Summary

\`{paint-order:stroke|fill}\` produced \`paint-order: stroke|fill\` (literal pipe) which browsers reject. Master CSS uses \`|\` as a class-name-safe space separator (because actual spaces would break HTML class attribute parsing) but the \`{ ... }\` group declarer was preserving the literal pipe in the value.

## Changes

- \`packages/core/src/declarers/core.group.ts:addProp\` — replaces \`|\` with space when extracting the property value
- New \`tests/issue-363-fallback.test.ts\` — 4 cases covering single value, 2-value list, 3-value list, and \`bg:white|red\` regression (regular non-group rule still works)

## Testing

- 4/4 new tests pass; 109 core test files still pass
- Real Chrome verification via \`agent-browser\`: pre-fix \`paint-order:stroke|fill\` → computed \`paint-order: "normal"\` (declaration rejected); post-fix \`paint-order:stroke fill\` → computed \`"stroke"\` (browser accepts and normalizes)