### PR TITLE
Fix(Validator): False positives on min()/max()/clamp() and modern CSS

### DIFF
--- a/packages/eslint-plugin/tests/issues/405/test.ts
+++ b/packages/eslint-plugin/tests/issues/405/test.ts
@@ -1,0 +1,19 @@
+import rule from '../../../src/rules/class-validation'
+import { jsxTester } from '../../testers'
+
+jsxTester.run('issue 405 323 331 math fns and modern css', rule, {
+    valid: [
+        // #405 — min/max/clamp must not raise false positive
+        { code: `<div class="w:min(50vw,200px)">a</div>` },
+        { code: `<div class="w:max(10rem,50%)">a</div>` },
+        { code: `<div class="w:clamp(10rem,5vw,20rem)">a</div>` },
+        // #323 — right:max(...) was reported as invalid
+        { code: `<div class="right:max(0px,1rem)">a</div>` },
+        // #358-style: clamp with bare arithmetic (auto-wrapped at parse, must not error here)
+        { code: `<div class="font-size:clamp(1rem,calc(2vw+1rem),3rem)">a</div>` },
+        // #331-style: modern properties should be valid
+        { code: `<div class="aspect:16/9">a</div>` },
+        { code: `<div class="rotate:45deg">a</div>` },
+    ],
+    invalid: []
+})

--- a/packages/validator/src/validate-css.ts
+++ b/packages/validator/src/validate-css.ts
@@ -1,6 +1,9 @@
 import { lexer, parse, walk, property as propertyName } from 'css-tree'
 import { type SyntaxError } from './types/syntax-error'
 
+// CSS math/comparison functions whose argument types css-tree may misjudge.
+const MATH_FN_REGEX = /\b(?:calc|min|max|clamp|sin|cos|tan|asin|acos|atan|atan2|exp|log|pow|sqrt|hypot|abs|sign|round|mod|rem)\(/i
+
 export default function validateCSS(text: string, parseOptions = {
     parseAtrulePrelude: false,
     parseRulePrelude: false,
@@ -133,8 +136,18 @@ export function validateDeclaration(property: string, value: any) {
             property
         }))
     } else if (error = isTargetError(lexer.matchProperty(property, value).error)) {
-        // TODO: https://github.com/master-co/css/issues/405
-        if (!error.css?.includes('min(') && !error.css?.includes('max(') && !error.css?.includes('clamp(')) {
+        // Suppress mismatches caused by CSS Values Module Level 4 math/comparison
+        // functions that css-tree's bundled syntax data does not yet describe.
+        // See issues #405, #323, #331. Check both the error fragment and the full
+        // value text — sometimes the mismatched fragment doesn't include the math
+        // function call (e.g. `right: max(0px, 1rem)` reports the bare `0px` arg).
+        const valueText = typeof value === 'string'
+            ? value
+            : value && typeof value.value === 'string'
+                ? value.value
+                : ''
+        const hasMathFn = MATH_FN_REGEX.test(error.css ?? '') || MATH_FN_REGEX.test(valueText)
+        if (!hasMathFn) {
             errors.push(Object.assign(error, {
                 property,
                 ...error.rawMessage === 'Mismatch' &&

--- a/packages/validator/tests/issue-405-math-fns.test.ts
+++ b/packages/validator/tests/issue-405-math-fns.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'vitest'
+import validateCSS from '../src/validate-css'
+
+describe('issue #405 / #323 / #331: validator must accept CSS Values 4 math fns', () => {
+    test('width: min(50vw, 200px) is valid', () => {
+        expect(validateCSS('.foo { width: min(50vw, 200px) }')).toEqual([])
+    })
+
+    test('width: max(10rem, 50%) is valid', () => {
+        expect(validateCSS('.foo { width: max(10rem, 50%) }')).toEqual([])
+    })
+
+    test('width: clamp(10rem, 5vw, 20rem) is valid', () => {
+        expect(validateCSS('.foo { width: clamp(10rem, 5vw, 20rem) }')).toEqual([])
+    })
+
+    test('right: max(0px, env(safe-area-inset-right)) is valid (issue #323)', () => {
+        expect(validateCSS('.foo { right: max(0px, 1rem) }')).toEqual([])
+    })
+
+    test('font-size: clamp(1rem, 2vw + 1rem, 3rem) is valid', () => {
+        expect(validateCSS('.foo { font-size: clamp(1rem, calc(2vw + 1rem), 3rem) }')).toEqual([])
+    })
+
+    test('inset: max(...) (block-shorthand) is valid', () => {
+        expect(validateCSS('.foo { inset: max(0px, 8px) }')).toEqual([])
+    })
+
+    test('margin: clamp(1rem, 5%, 3rem) is valid', () => {
+        expect(validateCSS('.foo { margin: clamp(1rem, 5%, 3rem) }')).toEqual([])
+    })
+
+    test('truly invalid value still errors (regression)', () => {
+        const errs = validateCSS('.foo { width: notarealvalue }')
+        expect(errs.length).toBeGreaterThan(0)
+    })
+
+    // Edge cases that may still surface false positives
+    test('width: min(calc(100vw - 2rem), 800px) (nested calc inside min)', () => {
+        expect(validateCSS('.foo { width: min(calc(100vw - 2rem), 800px) }')).toEqual([])
+    })
+
+    test('right: max(0px, env(safe-area-inset-right)) with env() inside', () => {
+        expect(validateCSS('.foo { right: max(0px, env(safe-area-inset-right)) }')).toEqual([])
+    })
+
+    test('rotate: 45deg (issue #331-style: valid CSS verified as unknown)', () => {
+        expect(validateCSS('.foo { rotate: 45deg }')).toEqual([])
+    })
+
+    test('aspect-ratio: 16/9 (modern property)', () => {
+        expect(validateCSS('.foo { aspect-ratio: 16/9 }')).toEqual([])
+    })
+
+    test('contain: layout (modern property values)', () => {
+        expect(validateCSS('.foo { contain: layout }')).toEqual([])
+    })
+
+    test('container-type: inline-size', () => {
+        expect(validateCSS('.foo { container-type: inline-size }')).toEqual([])
+    })
+
+    test('color: oklch(0.5 0.1 240) (modern color function)', () => {
+        expect(validateCSS('.foo { color: oklch(0.5 0.1 240) }')).toEqual([])
+    })
+
+    test('background: linear-gradient(in oklch, red, blue) (color interpolation)', () => {
+        expect(validateCSS('.foo { background: linear-gradient(in oklch, red, blue) }')).toEqual([])
+    })
+})


### PR DESCRIPTION
Closes #405, #323, #331.

## Summary

The validator's existing TODO-marked workaround for math functions only checked the error fragment (\`error.css\`) for \`min(\`/\`max(\`/\`clamp(\` substrings. Some mismatches surface only a sub-token (e.g. \`right: max(0px, 1rem)\` reports the bare \`0px\` arg), so the suppression missed valid usages and the user saw false positives.

## Changes

- \`packages/validator/src/validate-css.ts\` — (a) check the FULL value text in addition to \`error.css\` (b) extended math-fn list to all CSS Values 4 functions: \`calc\`/\`min\`/\`max\`/\`clamp\`/\`sin\`/\`cos\`/\`tan\`/\`asin\`/\`acos\`/\`atan\`/\`atan2\`/\`exp\`/\`log\`/\`pow\`/\`sqrt\`/\`hypot\`/\`abs\`/\`sign\`/\`round\`/\`mod\`/\`rem\`
- New \`packages/validator/tests/issue-405-math-fns.test.ts\` — 16 cases (min/max/clamp/calc/oklch/rotate/aspect-ratio/contain/container-type all valid; truly invalid still errors)
- New \`packages/eslint-plugin/tests/issues/405/test.ts\` — 7 RuleTester cases including \`right:max(0px,1rem)\` (#323), \`font-size:clamp(1rem,calc(2vw+1rem),3rem)\`, \`aspect:16/9\`, \`rotate:45deg\`

## Scope note

\`#338\` was originally tagged in the same umbrella but it's a separate feature (recommended-syntax warnings, new lint rules), not a validator suppression issue. Shipped separately as PR #420 (feat/338-eslint-recommended-syntax).

## Testing

- 16/16 validator tests pass; 7/7 eslint-plugin tests pass; all 14 plugin test files + all 3 validator test files green