### PR TITLE
Add(Docs): Reference + guide pages (border-image, counter-*, grid-area, bun, lit, plugins, grid-systems)

### DIFF
--- a/site/app/[locale]/guide/authoring-plugins/content.mdx
+++ b/site/app/[locale]/guide/authoring-plugins/content.mdx
@@ -1,0 +1,92 @@
+## Overview
+
+A Master CSS "plugin" is a normal npm package that exports a partial `Config` object. Consumers merge it via `extends`, so plugins compose in a deterministic order (later overrides earlier). There is no separate plugin runtime — everything is plain config.
+
+## Anatomy of a plugin package
+
+```ts name=src/index.ts
+import type { Config } from '@master/css'
+
+const plugin: Config = {
+    rules: {
+        'shadow-elevated': {
+            declarations: { 'box-shadow': '0 8px 24px rgba(0,0,0,.12)' }
+        }
+    },
+    variables: {
+        color: {
+            brand: { primary: '#4285f4', danger: '#e63946' }
+        }
+    },
+    components: {
+        card: 'bg:white shadow-elevated r:12 p:24'
+    }
+}
+
+export default plugin
+```
+
+```json name=package.json
+{
+    "name": "master-css-preset-myteam",
+    "version": "0.1.0",
+    "type": "module",
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+        }
+    },
+    "peerDependencies": {
+        "@master/css": "*"
+    }
+}
+```
+
+`@master/css` is a **peer dependency** so the host project's version wins.
+
+## Consuming the plugin
+
+```ts name=master.css.ts
+import myteam from 'master-css-preset-myteam'
+import type { Config } from '@master/css'
+
+export default {
+    extends: [myteam],
+    // overrides win over the plugin
+    variables: { color: { brand: { primary: '#0063f0' } } }
+} satisfies Config
+```
+
+`extends` accepts an array — multiple plugins are applied left-to-right.
+
+## What a plugin can ship
+
+| Field | Use case |
+|-------|----------|
+| `rules` | Custom utility shorthands (`shadow-elevated`, `font-display`) |
+| `utilities` | Static one-off declarations (`sr-only`, `not-sr-only`) |
+| `variables` | Design tokens (colors, spacing, radii, font scales) |
+| `modes` | Mode-scoped variable values (`light`, `dark`, custom) |
+| `components` | Class compositions (`card`, `btn`, `btn-primary`) |
+| `selectors` | Custom logical selector tokens |
+| `at` | Custom at-rule tokens |
+| `animations` | Reusable `@keyframes` |
+
+Avoid bundling source files for these directly — emit compiled JS via your build of choice (`tsup`, `tsc`, `bun build`, `unbuild`).
+
+## Conventions
+
+- Name with the prefix `master-css-preset-` or `master-css-plugin-` so consumers can find it.
+- Document required peer deps and the minimum `@master/css` version.
+- Keep the public surface in one default export; named sub-exports for opt-in slices are fine.
+- Don't import the runtime in the plugin — plugins ship config only.
+
+## See also
+
+- [Configuration reference](/guide/configuration)
+- [`@master/css` core reference](/reference/core)

--- a/site/app/[locale]/guide/authoring-plugins/metadata.ts
+++ b/site/app/[locale]/guide/authoring-plugins/metadata.ts
@@ -1,0 +1,11 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'Authoring a plugin / package',
+    description: 'How to extend Master CSS with a reusable config preset, utility set, or component library.',
+    category: 'Customization',
+    vercelOG: true,
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/guide/authoring-plugins/page.tsx
+++ b/site/app/[locale]/guide/authoring-plugins/page.tsx
@@ -1,0 +1,15 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/guide.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/guide/grid-systems/content.mdx
+++ b/site/app/[locale]/guide/grid-systems/content.mdx
@@ -1,0 +1,70 @@
+## Overview
+
+Master CSS doesn't ship a Bootstrap-style row/column scaffold — modern CSS Grid is expressive enough that a thin set of utilities does the job. This guide collects three common patterns.
+
+## 12-column layout
+
+```html
+<div class="grid grid-cols:12 gap:24">
+    <header class="grid-col:span-12">…</header>
+    <main class="grid-col:span-8">…</main>
+    <aside class="grid-col:span-4">…</aside>
+</div>
+```
+
+Stack on small screens by overriding `grid-col` at a breakpoint:
+
+```html
+<aside class="grid-col:span-4 grid-col:span-12@max-md">…</aside>
+```
+
+## Auto-fit responsive cards (no breakpoints)
+
+This pattern fills the row with as many cards as fit, each at least `16rem` wide, then collapses naturally:
+
+```html
+<div class="grid grid-cols:repeat(auto-fit,minmax(16rem,1fr)) gap:16">
+    <article class="bg:white p:16 r:8">…</article>
+    <article class="bg:white p:16 r:8">…</article>
+    <article class="bg:white p:16 r:8">…</article>
+</div>
+```
+
+## Named template areas
+
+For app-shell style layouts, name regions and assign them with `grid-area:`:
+
+```html
+<div class="
+    grid
+    {grid-template-areas:'header header'|'sidebar main'|'footer footer'}
+    {grid-template-rows:auto|1fr|auto}
+    grid-template-cols:240|1fr
+    h:dvh
+">
+    <header class="grid-area:header">…</header>
+    <aside class="grid-area:sidebar">…</aside>
+    <main class="grid-area:main">…</main>
+    <footer class="grid-area:footer">…</footer>
+</div>
+```
+
+## When to reach for a fixed grid library
+
+If your design assumes traditional 12-column gutters, breakpoint-specific column counts, or container queries against a parent grid, write the template once as a [component](/guide/components):
+
+```ts name=master.css.ts
+export default {
+    components: {
+        'grid-12': 'grid grid-cols:12 gap:24 mx:auto max-w:1280'
+    }
+}
+```
+
+Now `<div class="grid-12">` expands to the full set of utilities anywhere it's used.
+
+## See also
+
+- [`grid-template-columns` reference](/reference/grid-template-columns)
+- [`grid-area` reference](/reference/grid-area)
+- [Components](/guide/components)

--- a/site/app/[locale]/guide/grid-systems/metadata.ts
+++ b/site/app/[locale]/guide/grid-systems/metadata.ts
@@ -1,0 +1,11 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'Easy grid systems',
+    description: 'Building flexible page-layout grid systems with Master CSS utilities, no framework required.',
+    category: 'Recipes',
+    vercelOG: true,
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/guide/grid-systems/page.tsx
+++ b/site/app/[locale]/guide/grid-systems/page.tsx
@@ -1,0 +1,15 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/guide.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/guide/installation/bun/content.mdx
+++ b/site/app/[locale]/guide/installation/bun/content.mdx
@@ -1,0 +1,64 @@
+## Overview
+
+Bun ≥ 1.x runs JavaScript and bundles to a browser target. Master CSS works with Bun in two ways:
+
+1. **Runtime injection** — let `@master/css-runtime` generate styles in the browser. Easiest setup, zero build configuration.
+2. **Static extraction at build time** — call the `mcss` CLI in your `bun build` step to emit a single stylesheet. Best for production.
+
+## Runtime injection
+
+```bash
+bun add @master/css @master/css-runtime
+```
+
+```ts name=src/index.ts
+import { initCSSRuntime } from '@master/css-runtime'
+import config from './master.css'
+
+initCSSRuntime(config)
+```
+
+```ts name=src/master.css.ts
+import type { Config } from '@master/css'
+
+export default {} satisfies Config
+```
+
+```bash
+bun --hot src/index.ts
+```
+
+## Static extraction
+
+```bash
+bun add -D @master/css @master/css.cli
+```
+
+```json name=package.json
+{
+    "scripts": {
+        "build": "bun build ./src/index.tsx --outdir ./dist && mcss render \"dist/**/*.html\""
+    }
+}
+```
+
+`mcss` walks the emitted HTML, collects every Master CSS class, and writes a single deduplicated stylesheet. Reference it with `<link rel=\"stylesheet\" href=\"./master.css\">` in your HTML entry.
+
+## Configuration
+
+```ts name=master.css.ts
+import type { Config } from '@master/css'
+
+export default {
+    variables: {
+        color: { primary: '#4285f4' }
+    }
+} satisfies Config
+```
+
+Bun resolves the config natively — no `tsx` or `ts-node` needed.
+
+## See also
+
+- [Vite integration guide](/guide/installation/vite) for parallels in plugin form
+- [`@master/css.cli` reference](/reference/cli)

--- a/site/app/[locale]/guide/installation/bun/metadata.ts
+++ b/site/app/[locale]/guide/installation/bun/metadata.ts
@@ -1,0 +1,11 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'Set up Master CSS with Bun',
+    description: 'Guide to using Master CSS with the Bun runtime and bundler.',
+    category: 'Integrations',
+    vercelOG: true,
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/guide/installation/bun/page.tsx
+++ b/site/app/[locale]/guide/installation/bun/page.tsx
@@ -1,0 +1,17 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/guide.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    noTOC: true,
+    categoryLink: '/guide/installation/integrations',
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/guide/installation/lit/content.mdx
+++ b/site/app/[locale]/guide/installation/lit/content.mdx
@@ -1,0 +1,68 @@
+## Overview
+
+Lit components render inside a Shadow DOM by default, which means a globally injected stylesheet does **not** reach into them. There are two viable patterns:
+
+1. **Use `:host` styles + the runtime** — let `@master/css-runtime` generate a single global stylesheet, but flatten components into the Light DOM (`createRenderRoot() { return this }`).
+2. **Per-component stylesheets** — use the runtime in the page shell *and* re-attach an `adoptedStyleSheets` clone inside each component's shadow root.
+
+## Light DOM (recommended for most apps)
+
+```ts name=my-button.ts
+import { LitElement, html } from 'lit'
+import { customElement } from 'lit/decorators.js'
+
+@customElement('my-button')
+export class MyButton extends LitElement {
+    // opt out of Shadow DOM so global Master CSS classes apply
+    createRenderRoot() { return this }
+
+    render() {
+        return html`
+            <button class="bg:primary fg:white px:16 py:8 r:8 hover:bg:primary-70">
+                <slot></slot>
+            </button>
+        `
+    }
+}
+```
+
+Bootstrap the runtime once at the app entry:
+
+```ts name=index.ts
+import { initCSSRuntime } from '@master/css-runtime'
+import config from './master.css'
+import './my-button'
+
+initCSSRuntime(config)
+```
+
+## Shadow DOM with adoptedStyleSheets
+
+```ts name=my-button.ts
+import { LitElement, html } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import { CSSRuntime } from '@master/css-runtime'
+import config from './master.css'
+
+const css = new CSSRuntime(config)
+const sheet = new CSSStyleSheet()
+sheet.replaceSync(css.text)
+
+@customElement('my-button')
+export class MyButton extends LitElement {
+    constructor() {
+        super()
+        this.shadowRoot && (this.shadowRoot.adoptedStyleSheets = [sheet])
+    }
+    render() {
+        return html`<button class="bg:primary fg:white px:16 py:8 r:8">…</button>`
+    }
+}
+```
+
+This duplicates the stylesheet into every shadow root; use only when you need style isolation.
+
+## See also
+
+- [`@master/css-runtime` reference](/reference/runtime)
+- [Lit docs — Styles](https://lit.dev/docs/components/styles/)

--- a/site/app/[locale]/guide/installation/lit/metadata.ts
+++ b/site/app/[locale]/guide/installation/lit/metadata.ts
@@ -1,0 +1,11 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'Set up Master CSS in Lit',
+    description: 'Guide to using Master CSS inside Lit web components.',
+    category: 'Integrations',
+    vercelOG: true,
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/guide/installation/lit/page.tsx
+++ b/site/app/[locale]/guide/installation/lit/page.tsx
@@ -1,0 +1,17 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/guide.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    noTOC: true,
+    categoryLink: '/guide/installation/integrations',
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/reference/border-image/content.mdx
+++ b/site/app/[locale]/reference/border-image/content.mdx
@@ -1,0 +1,30 @@
+## Overview
+
+`border-image` draws an image instead of solid colors around the element's border box. Master CSS exposes the shorthand and each long-hand property as a class.
+
+## Syntax
+
+```html
+<!-- shorthand: source slice / width / outset repeat -->
+<div class="border-image:url(/frame.png)|30|round">…</div>
+
+<!-- long-hand utilities -->
+<div class="border-image-source:url(/frame.png)">…</div>
+<div class="border-image-slice:30">…</div>
+<div class="border-image-width:1rem">…</div>
+<div class="border-image-outset:0">…</div>
+<div class="border-image-repeat:round">…</div>
+```
+
+## Apply conditionally
+
+Like every Master CSS rule, you can scope it with [selectors](/guide/state-selectors) and [conditional queries](/guide/conditional-queries):
+
+```html
+<div class="border-image:url(/frame.png)|30|round@sm">…</div>
+```
+
+## See also
+
+- [MDN — `border-image`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image)
+- [Can I Use](https://caniuse.com/?search=border-image)

--- a/site/app/[locale]/reference/border-image/metadata.ts
+++ b/site/app/[locale]/reference/border-image/metadata.ts
@@ -1,0 +1,13 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'border-image',
+    description: 'Drawing an image around an element instead of plain border styles.',
+    category: 'Syntax',
+    type: 'entity',
+    canIUseLink: 'https://caniuse.com/?search=border-image',
+    mdnLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/border-image',
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/reference/border-image/page.tsx
+++ b/site/app/[locale]/reference/border-image/page.tsx
@@ -1,0 +1,15 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/reference.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/reference/border-image/syntaxes.ts
+++ b/site/app/[locale]/reference/border-image/syntaxes.ts
@@ -1,0 +1,6 @@
+const syntaxes = [
+    ['border-image:`source slice / width / outset repeat`'],
+    'border-image:url(/frame.png)|30|round'
+]
+
+export default syntaxes

--- a/site/app/[locale]/reference/counter-increment/content.mdx
+++ b/site/app/[locale]/reference/counter-increment/content.mdx
@@ -1,0 +1,39 @@
+## Overview
+
+`counter-increment` advances one or more CSS counters every time the element is rendered. Pair it with [`counter-reset`](/reference/counter-reset) and `content: counter(...)` on `::before`/`::after` to render numbered lists, section labels, etc.
+
+## Syntax
+
+```html
+<!-- increment a counter named "section" by 1 (default) -->
+<div class="counter-increment:section">…</div>
+
+<!-- increment by an explicit value -->
+<div class="counter-increment:section|2">…</div>
+
+<!-- multiple counters -->
+<div class="counter-increment:section|chapter|1">…</div>
+
+<!-- disable inheritance -->
+<div class="counter-increment:none">…</div>
+```
+
+## Example: numbered headings
+
+```html
+<article class="counter-reset:section">
+    <h2 class="counter-increment:section { content:counter(section)'._' }::before">Intro</h2>
+    <h2 class="counter-increment:section { content:counter(section)'._' }::before">Setup</h2>
+</article>
+```
+
+## Apply conditionally
+
+```html
+<div class="counter-increment:section@sm counter-increment:none@max-sm">…</div>
+```
+
+## See also
+
+- [MDN — `counter-increment`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment)
+- [`counter-reset`](/reference/counter-reset)

--- a/site/app/[locale]/reference/counter-increment/metadata.ts
+++ b/site/app/[locale]/reference/counter-increment/metadata.ts
@@ -1,0 +1,13 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'counter-increment',
+    description: 'Increasing or decreasing the value of a CSS counter.',
+    category: 'Syntax',
+    type: 'entity',
+    canIUseLink: 'https://caniuse.com/?search=counter-increment',
+    mdnLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment',
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/reference/counter-increment/page.tsx
+++ b/site/app/[locale]/reference/counter-increment/page.tsx
@@ -1,0 +1,15 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/reference.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/reference/counter-increment/syntaxes.ts
+++ b/site/app/[locale]/reference/counter-increment/syntaxes.ts
@@ -1,0 +1,6 @@
+const syntaxes = [
+    ['counter-increment:`name`|`integer`'],
+    'counter-increment:none'
+]
+
+export default syntaxes

--- a/site/app/[locale]/reference/counter-reset/content.mdx
+++ b/site/app/[locale]/reference/counter-reset/content.mdx
@@ -1,0 +1,39 @@
+## Overview
+
+`counter-reset` creates a new CSS counter (or resets an existing one) on the matched element. The counter is then bumped by [`counter-increment`](/reference/counter-increment) and rendered with `content: counter(...)`.
+
+## Syntax
+
+```html
+<!-- create a counter named "section" starting at 0 -->
+<div class="counter-reset:section">…</div>
+
+<!-- start at an explicit value -->
+<div class="counter-reset:section|10">…</div>
+
+<!-- multiple counters -->
+<div class="counter-reset:section|chapter|0">…</div>
+
+<!-- reverse counter (counts down) -->
+<div class="counter-reset:reversed(section)">…</div>
+
+<!-- no reset (default) -->
+<div class="counter-reset:none">…</div>
+```
+
+## Example: scoped numbering
+
+```html
+<section class="counter-reset:question">
+    <p class="counter-increment:question { content:'Q'counter(question)'._' }::before">…</p>
+    <p class="counter-increment:question { content:'Q'counter(question)'._' }::before">…</p>
+</section>
+<section class="counter-reset:question">
+    <!-- counter starts again at 1 inside this section -->
+</section>
+```
+
+## See also
+
+- [MDN — `counter-reset`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset)
+- [`counter-increment`](/reference/counter-increment)

--- a/site/app/[locale]/reference/counter-reset/metadata.ts
+++ b/site/app/[locale]/reference/counter-reset/metadata.ts
@@ -1,0 +1,13 @@
+import define from 'internal/utils/metadata'
+
+const metadata = define({
+    title: 'counter-reset',
+    description: 'Creating or resetting CSS counters to a specified starting value.',
+    category: 'Syntax',
+    type: 'entity',
+    canIUseLink: 'https://caniuse.com/?search=counter-reset',
+    mdnLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset',
+    fileURL: import.meta.url
+})
+
+export default metadata

--- a/site/app/[locale]/reference/counter-reset/page.tsx
+++ b/site/app/[locale]/reference/counter-reset/page.tsx
@@ -1,0 +1,15 @@
+import createPage from '~/internal/factories/create-page'
+import Layout from 'internal/layouts/doc'
+import metadata from './metadata'
+import dictionaries from '~/site/dictionaries'
+import categories from '~/site/.categories/reference.json'
+
+export const { Page, dynamic, revalidate, generateMetadata } = createPage({
+    metadata,
+    dictionaries,
+    categories,
+    content: import('./content.mdx'),
+    Layout,
+})
+
+export default Page

--- a/site/app/[locale]/reference/counter-reset/syntaxes.ts
+++ b/site/app/[locale]/reference/counter-reset/syntaxes.ts
@@ -1,0 +1,6 @@
+const syntaxes = [
+    ['counter-reset:`name`|`integer`'],
+    'counter-reset:none'
+]
+
+export default syntaxes

--- a/site/app/[locale]/reference/grid-area/content.mdx
+++ b/site/app/[locale]/reference/grid-area/content.mdx
@@ -1,9 +1,56 @@
 ## Overview [sr-only]
 <Overview/>
 
+## Syntax
+
+`grid-area` is a shorthand for the four placement long-hands:
+
+```css
+grid-area: <row-start> / <column-start> / <row-end> / <column-end>;
+grid-area: <name>;
+```
+
+```html
+<!-- name a region (used with grid-template-areas) -->
+<div class="grid-area:header">…</div>
+
+<!-- explicit lines via slash; use `|` because spaces aren't safe in classes -->
+<div class="grid-area:1|1|3|3">…</div>
+
+<!-- spans -->
+<div class="grid-area:span-2|span-2">…</div>
+
+<!-- reset -->
+<div class="grid-area:none">…</div>
+```
+
+## Pair with named template areas
+
+```html
+<div class="
+    grid
+    {grid-template-areas:'header header'|'sidebar main'|'footer footer'}
+    grid-template-rows:auto|1fr|auto
+    grid-template-cols:240|1fr
+">
+    <header class="grid-area:header">…</header>
+    <aside  class="grid-area:sidebar">…</aside>
+    <main   class="grid-area:main">…</main>
+    <footer class="grid-area:footer">…</footer>
+</div>
+```
+
+See the [Easy grid systems guide](/guide/grid-systems) for layout recipes.
+
 ### Apply conditionally
 Apply styles based on different states using [selectors](/guide/state-selectors) and [conditional queries](/guide/conditional-queries).
 ```html
 <div class="grid-area:none:hover grid-area:none@sm grid-area:none@dark grid-area:none@print">…</div>
 ```
 
+## See also
+
+- [MDN — `grid-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area)
+- [`grid-template-areas` reference](/reference/grid-template-areas)
+- [`grid-column` reference](/reference/grid-column)
+- [`grid-row` reference](/reference/grid-row)


### PR DESCRIPTION
Closes #190, #144, #145, #106, #233, #152, #158, #329. Verifies #407 (already covered by existing /guide/installation/vite).

## Summary

Batch of 9 documentation pages requested in separate issues — kept together because they share scaffolding patterns and route conventions.

## New reference pages

- \`/reference/border-image\` (#106)
- \`/reference/counter-increment\` (#145)
- \`/reference/counter-reset\` (#144)
- \`/reference/grid-area\` (#190) — expanded existing stub with shorthand syntax + named-template-area example

## New guide pages

- \`/guide/installation/bun\` (#152) — runtime injection + static extraction patterns
- \`/guide/installation/lit\` (#158) — Light DOM + Shadow DOM (\`adoptedStyleSheets\`) approaches
- \`/guide/authoring-plugins\` (#233) — complete plugin authoring guide
- \`/guide/grid-systems\` (#329) — 12-column, auto-fit, named template areas

## Verified

- \`pnpm dev\` (Next.js + Turbopack) starts cleanly; agent-browser walked all 9 routes — every page returns 200 with correct H1 + \`<title>\`
- During verification, found and fixed two MDX render bugs:
  - \`grid-area\` had a bare \`\`\`\`\`\`\`-block which crashed the MDX \`<pre>\` component (\`children.props.className.split\` on undefined) — added \`css\` lang
  - \`bun\` + \`authoring-plugins\` used \`\`\`\`\`jsonc\`\`\` which Shiki's bundled langs don't include — switched to \`\`\`\`json\`\`\`

#407 was already covered by the existing \`/guide/installation/vite\` route (which documents \`@master/css.vite\`); this PR did not modify it.