### PR TITLE
Fix(Language): Comment scope guard + bg:url() / pipe highlighting

### DIFF
--- a/packages/language/syntaxes/master-css.injection-class.json
+++ b/packages/language/syntaxes/master-css.injection-class.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-class",
-    "injectionSelector": "L:meta.attribute.class string.quoted",
+    "injectionSelector": "L:meta.attribute.class string.quoted -comment",
     "patterns": [
         {
             "include": "source.master-css"

--- a/packages/language/syntaxes/master-css.injection-react.json
+++ b/packages/language/syntaxes/master-css.injection-react.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-react",
-    "injectionSelector": "L:meta.tag,L:source.mdx",
+    "injectionSelector": "L:meta.tag -comment, L:source.mdx -comment",
     "patterns": [
         {
             "include": "#highlight-class-quoted-double"

--- a/packages/language/syntaxes/master-css.injection-string.json
+++ b/packages/language/syntaxes/master-css.injection-string.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-string",
-    "injectionSelector": "L:meta.embedded.block.master-css.class string.quoted",
+    "injectionSelector": "L:meta.embedded.block.master-css.class string.quoted -comment",
     "patterns": [
         {
             "include": "source.master-css"

--- a/packages/language/syntaxes/master-css.injection-vue.json
+++ b/packages/language/syntaxes/master-css.injection-vue.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-vue",
-    "injectionSelector": "L:source.vue meta.attribute.directive meta.array.literal string.template",
+    "injectionSelector": "L:source.vue meta.attribute.directive meta.array.literal string.template -comment",
     "patterns": [
         {
             "include": "source.master-css"

--- a/packages/language/syntaxes/master-css.json
+++ b/packages/language/syntaxes/master-css.json
@@ -208,7 +208,7 @@
                     "match": "(?<=(?:[^\\s;:]+:|[@~]|(?:[^\\s;\\:\\|,]+\\())[^\\s;\\:\"'`]*)(\\|)",
                     "captures": {
                         "1": {
-                            "name": "comment.block"
+                            "name": "punctuation.separator.master-css"
                         }
                     }
                 },
@@ -273,7 +273,7 @@
         "master-css-selector": {
             "patterns": [
                 {
-                    "match": "(?<![\\|/])(\\.)(?!\\d)([^\\s;'\"`@:><.\\[\\]_\\+\\(\\),]*)",
+                    "match": "(?<![A-Za-z0-9_\\-\\|/])(\\.)(?!\\d)([^\\s;'\"`@:><.\\[\\]_\\+\\(\\),]*)",
                     "captures": {
                         "1": {
                             "name": "entity.other.attribute-name.class.css"


### PR DESCRIPTION
Closes #361, #217.

## Summary

Two TextMate grammar fixes:

### #361 — comment scope guard

\`master-css.injection-{class,react,vue,string}.json\` injection selectors didn't exclude comment scopes. Only \`injection-js.json\` had \`-comment\` in its selector. This PR aligns the four others, defense-in-depth for comment-toggle scenarios.

\`\`\`diff
-"injectionSelector": "L:meta.tag,L:source.mdx"
+"injectionSelector": "L:meta.tag -comment, L:source.mdx -comment"
\`\`\`

### #217 — \`|\` styling + \`bg:url(/foo.png)\` mis-parse

\`master-css.json\` had two regex bugs:

1. The \`|\` separator captured \`name: "comment.block"\` — semantically wrong (theme tools render in comment colour, accessibility flags it as a comment). Changed to \`punctuation.separator.master-css\`.
2. The class-selector pattern \`(?<![\\|/])(\\.)…\` was too loose — \`.png\` inside \`bg:url(/foo.png)\` had \`o\` (not \`|\`/\`/\`) before the \`.\` and matched as a CSS class. Tightened the lookbehind to \`(?<![A-Za-z0-9_\\-\\|/])\` so a class selector only fires at a token boundary (whitespace, \`:\`, \`(\`, etc.).

## Verification

Used \`vscode-textmate\` + Shiki-bundled host grammars to tokenize fixture lines:

- TSX live \`className="bg:white"\` → token has \`support.type.property-name.css\` (master-css fingerprint)
- TSX commented \`// className="bg:white"\` → token only has \`comment.line.double-slash.tsx\` (no master-css)
- HTML \`<!-- <div class="bg:white"> -->\` → only has \`comment.block.html\`
- Post-fix \`bg:url(/foo.png)|cover\`: \`|\` scope = \`punctuation.separator.master-css\` (was \`comment.block\`); \`.png\` no longer carries class-selector scope
- Regression: \`bg:white .btn\` — the \`.btn\` after a space still tokenizes as \`entity.other.attribute-name.class.css\`

## Honest caveat for #361

The same comment exclusion happens on \`rc\` without my fix, because TSX/HTML host grammars already absorb the comment scope and don't surface inner \`string.quoted\`/\`meta.tag\` scopes that the master-css injection selector would match. The \`-comment\` guard is **defense-in-depth** — structurally correct, matching VSCode convention — but the user-visible symptom in #361 may have a different root cause (e.g. \`classNames(...)\` function-call context, language-configuration commentToken). The fix is worth keeping; it's not strictly proven to address the user's exact scenario.

\`#217\` is fully verified by tokenization.

## Repro scripts

\`/tmp/grammar-test/\` (vscode-textmate + vscode-oniguruma + shiki for host grammars). \`packages/language/\` has no test infra today; adding fixture-snapshot tests is its own work-item.