### PR TITLE
Add(CSS): View Transitions API foundation (Layer 1 + 2)

### DIFF
--- a/packages/core/src/config/rules.ts
+++ b/packages/core/src/config/rules.ts
@@ -589,6 +589,13 @@ const rules = {
         type: SyntaxRuleType.Native,
         namespaces: ['spacing']
     },
+    // View Transitions API (CSS View Transitions Level 1 / 2). #265 foundation.
+    'view-transition-name': {
+        type: SyntaxRuleType.Native
+    },
+    'view-transition-class': {
+        type: SyntaxRuleType.Native
+    },
     'translate()': {
         declarations: ['transform'],
         unit: 'rem',

--- a/packages/core/src/config/selectors.ts
+++ b/packages/core/src/config/selectors.ts
@@ -20,6 +20,12 @@ const selectors = {
     '::slider-runnable-track': '::-webkit-slider-runnable-track',
     '::resizer': '::-webkit-resizer',
     '::progress': '::-webkit-progress',
+    // View Transitions API short aliases (#265 Layer 2)
+    '::vt': '::view-transition',
+    '::vt-group': '::view-transition-group',
+    '::vt-image-pair': '::view-transition-image-pair',
+    '::vt-old': '::view-transition-old',
+    '::vt-new': '::view-transition-new',
 } satisfies SelectorDefinitions
 
 export default selectors

--- a/packages/core/src/utils/parse-selector.ts
+++ b/packages/core/src/utils/parse-selector.ts
@@ -97,8 +97,14 @@ export default function parseSelector(token: string, css: MasterCSS, isRaw = tru
             if (body) {
                 const lastColonIndex = pre.lastIndexOf(':')
                 if (lastColonIndex !== -1) {
-                    name = pre.slice(lastColonIndex)
-                    pre = pre.slice(0, lastColonIndex)
+                    // Walk back through any leading `:` (so `::foo(args)` keeps
+                    // both colons in `name`, not just the last one).
+                    let nameStart = lastColonIndex
+                    while (nameStart > 0 && pre[nameStart - 1] === ':') {
+                        nameStart--
+                    }
+                    name = pre.slice(nameStart)
+                    pre = pre.slice(0, nameStart)
                 }
             }
 

--- a/packages/core/tests/issue-265-view-transition.test.ts
+++ b/packages/core/tests/issue-265-view-transition.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from 'vitest'
+import { MasterCSS, config as defaultConfig } from '../src'
+
+describe('issue #265: View Transitions API foundation', () => {
+    test('view-transition-name applies as a CSS declaration', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('view-transition-name:hero')
+        expect(rule).toBeDefined()
+        expect(rule?.text).toContain('view-transition-name:hero')
+    })
+
+    test('view-transition-class applies as a CSS declaration', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('view-transition-class:product-card')
+        expect(rule).toBeDefined()
+        expect(rule?.text).toContain('view-transition-class:product-card')
+    })
+
+    test('view-transition-name:none disables transition for the element', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('view-transition-name:none')
+        expect(rule?.text).toContain('view-transition-name:none')
+    })
+
+    // Layer 2: pseudo-element selectors
+    test('::view-transition pseudo-element passes through verbatim', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('opacity:0::view-transition')
+        expect(rule?.text).toContain('::view-transition{opacity:0}')
+    })
+
+    test('::view-transition-old(name) parameterized pseudo emits both colons', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('opacity:0.5::view-transition-old(hero)')
+        // regression for parse-selector::pre.lastIndexOf(':') previously
+        // dropping the first colon of `::`
+        expect(rule?.text).toContain('::view-transition-old(hero)')
+        expect(rule?.text).not.toMatch(/[^:]:view-transition-old\(/)
+    })
+
+    test('::view-transition-new(name) emits both colons', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        expect(css.create('opacity:1::view-transition-new(hero)')?.text)
+            .toContain('::view-transition-new(hero)')
+    })
+
+    test('::vt short alias maps to ::view-transition', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        expect(css.create('opacity:0::vt')?.text).toContain('::view-transition{opacity:0}')
+    })
+
+    test('::vt-old(name) short alias maps to ::view-transition-old(name)', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        const rule = css.create('opacity:0.5::vt-old(hero)')
+        expect(rule?.text).toContain('::view-transition-old(hero)')
+    })
+
+    test('::vt-new(name) short alias works', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        expect(css.create('opacity:1::vt-new(hero)')?.text)
+            .toContain('::view-transition-new(hero)')
+    })
+
+    test('::vt-group(name) short alias works', () => {
+        const css = new MasterCSS(undefined, defaultConfig)
+        expect(css.create('animation:slide::vt-group(hero)')?.text)
+            .toContain('::view-transition-group(hero)')
+    })
+})


### PR DESCRIPTION
Closes #265 (foundation + Layer 2). Layer 3 (\`@view-transition\` at-rule) deferred to a separate PR with maintainer design call.

## Summary

Two layers of View Transitions API support:

### Layer 1 — element marking
- \`view-transition-name\` and \`view-transition-class\` registered as native rules
- \`<img class="view-transition-name:hero">\` works directly

### Layer 2 — pseudo-element selectors

Five short-form aliases under \`config/selectors.ts\`:

| Token | Maps to |
|-------|---------|
| \`::vt\` | \`::view-transition\` |
| \`::vt-group\` | \`::view-transition-group\` |
| \`::vt-image-pair\` | \`::view-transition-image-pair\` |
| \`::vt-old\` | \`::view-transition-old\` |
| \`::vt-new\` | \`::view-transition-new\` |

The \`(name)\` parameter sticks: \`opacity:0.5::vt-old(hero)\` produces \`::view-transition-old(hero){opacity:0.5}\`.

## Bonus fix in parse-selector

Building Layer 2 surfaced a parser bug: \`pre.lastIndexOf(':')\` for \`::name(args)\` only stripped ONE colon, so \`::view-transition-old(hero)\` rendered as \`:view-transition-old(hero)\` (single colon → typed as pseudo-class). Walk back through any leading consecutive colons so the full prefix is captured.

## Layer 3 — needs design call

\`@view-transition { navigation: auto; }\` is a document-level at-rule, not a class. Three options documented in \`css-docs/view-transitions-design.md\`:

1. New config field \`crossDocumentViewTransitions: 'auto'\` → core prepends the at-rule to output
2. Generic "raw declarations" config field
3. Don't ship — users add it manually

I lean to (1) but it needs maintainer choice on schema + scope.

## Testing

- 10 new test cases covering Layer 1 + the parser fix + each Layer 2 alias with parameter
- 109 core test files still pass
- Real Chrome verification: rendered stylesheet contains \`.opacity\\:0\\.5\\:\\:vt-old\\(hero\\)::view-transition-old(hero){opacity:0.5}\` with proper double colons; \`getComputedStyle(...).viewTransitionName === "hero"\`