### PR TITLE
Add(ESLint): class-recommended rule for axis-collapse suggestions

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -6,6 +6,7 @@ export default {
     rules: {
         '@master/css/class-order': 'warn',
         '@master/css/class-validation': 'error',
-        '@master/css/class-collision': 'warn'
+        '@master/css/class-collision': 'warn',
+        '@master/css/class-recommended': 'warn'
     },
 } as Linter.Config

--- a/packages/eslint-plugin/src/plugin.ts
+++ b/packages/eslint-plugin/src/plugin.ts
@@ -1,5 +1,6 @@
 import classCollision from './rules/class-collision'
 import classOrder from './rules/class-order'
+import classRecommended from './rules/class-recommended'
 import classValidation from './rules/class-validation'
 import { readFileSync } from 'fs'
 import type { TSESLint } from '@typescript-eslint/utils'
@@ -18,6 +19,7 @@ const plugin = {
     rules: {
         'class-collision': classCollision,
         'class-order': classOrder,
+        'class-recommended': classRecommended,
         'class-validation': classValidation
     }
 } as TSESLint.Linter.Plugin

--- a/packages/eslint-plugin/src/rules/class-recommended.ts
+++ b/packages/eslint-plugin/src/rules/class-recommended.ts
@@ -1,0 +1,180 @@
+import defineVisitors from '../utils/define-visitors'
+import resolveContext from '../utils/resolve-context'
+import createRule from '../create-rule'
+import settingsSchema from '../settings-schema'
+
+/**
+ * Issue #338 — recommend more idiomatic class shorthands.
+ *
+ * The first batch of recommendations focuses on axis collapses that have
+ * an unambiguous canonical form:
+ *
+ *   - mt:N + mr:N + mb:N + ml:N      → m:N
+ *   - mt:N + mb:N                    → my:N
+ *   - ml:N + mr:N                    → mx:N
+ *   - same for padding (pt/pb/pl/pr → p / py / px)
+ *   - same for inset (top/right/bottom/left → inset / inset-y / inset-x — when
+ *     the user's choosing the long-hands explicitly)
+ *
+ * Additional rules can be slotted into RECOMMENDATIONS below; each describes
+ * a set of "long-hand" keys that collapse to a "shorthand" key when all
+ * value tokens are equal and conditional-query suffixes match.
+ */
+
+interface ClassParse {
+    raw: string                  // full token, e.g. mt:8@sm:hover
+    head: string                 // key:value (no conditions), e.g. mt:8
+    rule: string                 // rule key, e.g. mt
+    value: string                // value, e.g. 8
+    suffix: string               // conditional-query suffixes, e.g. @sm:hover
+    important: boolean           // !important suffix
+}
+
+function parseClass(raw: string): ClassParse | null {
+    // Allow trailing ! for important.
+    const important = raw.endsWith('!')
+    const core = important ? raw.slice(0, -1) : raw
+    // Split on conditional-query suffix markers (@/~/:state) at the
+    // FIRST `@` or `:` that comes AFTER the value separator `:`.
+    const sepIndex = core.indexOf(':')
+    if (sepIndex < 0) return null
+    const rule = core.slice(0, sepIndex)
+    const after = core.slice(sepIndex + 1)
+    // The value ends at the next `@`, ` `, or non-trailing `:` — but pseudo
+    // states like `:hover`, breakpoints `@sm`, conditional queries `~print`
+    // are conditional suffixes. Match value as everything up to the first
+    // `@` / `~` / `:`.
+    const m = /^([^@~:]*)(.*)$/.exec(after)
+    if (!m) return null
+    const value = m[1]
+    const suffix = m[2]
+    if (!rule || !value) return null
+    return { raw, head: `${rule}:${value}`, rule, value, suffix, important }
+}
+
+interface Rec {
+    /** Long-hand rule keys (any 2 or 4) that collapse together. */
+    longhands: string[]
+    /** Resulting shorthand rule key. */
+    shorthand: string
+    /** Human description for the warning. */
+    label: string
+}
+
+const RECOMMENDATIONS: Rec[] = [
+    // margin
+    { longhands: ['mt', 'mr', 'mb', 'ml'], shorthand: 'm',  label: 'margin' },
+    { longhands: ['mt', 'mb'],             shorthand: 'my', label: 'margin-y' },
+    { longhands: ['ml', 'mr'],             shorthand: 'mx', label: 'margin-x' },
+    // padding
+    { longhands: ['pt', 'pr', 'pb', 'pl'], shorthand: 'p',  label: 'padding' },
+    { longhands: ['pt', 'pb'],             shorthand: 'py', label: 'padding-y' },
+    { longhands: ['pl', 'pr'],             shorthand: 'px', label: 'padding-x' },
+    // inset
+    { longhands: ['top', 'right', 'bottom', 'left'], shorthand: 'inset', label: 'inset' },
+    { longhands: ['top', 'bottom'],                  shorthand: 'inset-y', label: 'inset-y' },
+    { longhands: ['left', 'right'],                  shorthand: 'inset-x', label: 'inset-x' },
+]
+
+export default createRule({
+    name: 'class-recommended',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Suggest collapsing related long-hand utilities into the equivalent shorthand'
+        },
+        messages: {
+            recommend: '{{message}}',
+        },
+        fixable: 'code',
+        schema: [settingsSchema]
+    },
+    defaultOptions: [],
+    create(context) {
+        const { settings } = resolveContext(context)
+        return defineVisitors({ context, settings }, (_node, { raw, start, end, classNodes }) => {
+            // Build a map: head ("rule:value") → list of class nodes that share it
+            // Per recommendation: for each (group of long-hands), collect class nodes
+            // whose `rule` is in the group AND `value` is identical AND `suffix`/`important` match.
+            // If the group is fully covered, emit a warning.
+            const parsed: { node: any, p: ClassParse }[] = []
+            for (const cn of classNodes) {
+                const p = parseClass(cn.value)
+                if (p) parsed.push({ node: cn, p })
+            }
+
+            const reported = new Set<any>()  // class nodes already covered by a 4-side recommendation
+
+            for (const rec of RECOMMENDATIONS) {
+                // Bucket parsed classes by (value+suffix+important) so we only consider
+                // candidates that share value AND modifier conditions.
+                const buckets = new Map<string, Map<string, { node: any, p: ClassParse }>>()
+                for (const item of parsed) {
+                    if (reported.has(item.node)) continue
+                    if (!rec.longhands.includes(item.p.rule)) continue
+                    const key = `${item.p.value}|${item.p.suffix}|${item.p.important}`
+                    let bucket = buckets.get(key)
+                    if (!bucket) {
+                        bucket = new Map()
+                        buckets.set(key, bucket)
+                    }
+                    bucket.set(item.p.rule, item)
+                }
+
+                for (const [, m] of buckets) {
+                    if (m.size !== rec.longhands.length) continue
+                    if (rec.longhands.some((h) => !m.has(h))) continue
+                    const items = rec.longhands.map((h) => m.get(h) as { node: any, p: ClassParse })
+                    const sample = items[0]
+                    const replacementHead = `${rec.shorthand}:${sample.p.value}${sample.p.suffix}${sample.p.important ? '!' : ''}`
+                    const present = items.map((i) => i.node.value).join(', ')
+                    context.report({
+                        loc: items[0].node.loc,
+                        messageId: 'recommend',
+                        data: {
+                            message: `Use \`${replacementHead}\` instead of ${present} (collapse to ${rec.label} shorthand).`
+                        },
+                        fix(fixer) {
+                            // Single replaceTextRange covering the whole affected span,
+                            // so adjacent removals don't trigger ESLint's "overlapped fix"
+                            // guard. The span runs from the first long-hand's start to the
+                            // last long-hand's end; we re-emit the whole thing with the
+                            // first long-hand collapsed into the shorthand and the rest
+                            // (plus their preceding whitespace) dropped.
+                            const sortedNodes = items
+                                .map((i) => i.node)
+                                .sort((a, b) => a.range[0] - b.range[0])
+                            const text = context.sourceCode.getText()
+                            const spanStart = sortedNodes[0].range[0]
+                            const spanEnd = sortedNodes[sortedNodes.length - 1].range[1]
+                            const original = text.slice(spanStart, spanEnd)
+                            // Walk the span: the first occurrence of any long-hand becomes
+                            // the shorthand; all others (plus their preceding whitespace) drop.
+                            const longhandValues = new Set(items.map((i) => i.node.value))
+                            const tokens = original.split(/(\s+)/)  // keep whitespace separators
+                            let firstReplaced = false
+                            const out: string[] = []
+                            for (const tk of tokens) {
+                                if (longhandValues.has(tk)) {
+                                    if (!firstReplaced) {
+                                        out.push(replacementHead)
+                                        firstReplaced = true
+                                    } else {
+                                        // drop the previous whitespace too (collapse)
+                                        if (out.length > 0 && /^\s+$/.test(out[out.length - 1])) {
+                                            out.pop()
+                                        }
+                                    }
+                                } else {
+                                    out.push(tk)
+                                }
+                            }
+                            return fixer.replaceTextRange([spanStart, spanEnd], out.join(''))
+                        }
+                    })
+                    items.forEach((i) => reported.add(i.node))
+                }
+            }
+        })
+    },
+})

--- a/packages/eslint-plugin/src/utils/resolve-class-node.ts
+++ b/packages/eslint-plugin/src/utils/resolve-class-node.ts
@@ -122,7 +122,10 @@ export default function resolveClassNode(node: any, context: RuleContext<any, an
             type: 'class',
             value: classValue,
             raw: classRaw,
-            range: [start, endOffset],
+            // Bug fix: was `[start, endOffset]` — `start` is the className-value
+            // start, not this individual class's start. Wrong range[0] confused
+            // any rule that sorts class nodes by source position.
+            range: [startOffset, endOffset],
             loc: {
                 start: sourceCode.getLocFromIndex(startOffset),
                 end: sourceCode.getLocFromIndex(endOffset),

--- a/packages/eslint-plugin/tests/issues/338/test.ts
+++ b/packages/eslint-plugin/tests/issues/338/test.ts
@@ -1,0 +1,62 @@
+import rule from '../../../src/rules/class-recommended'
+import { jsxTester } from '../../testers'
+
+jsxTester.run('issue 338 class-recommended', rule, {
+    valid: [
+        // Already using shorthand — no warning
+        { code: `<div class="m:8">a</div>` },
+        { code: `<div class="my:8">a</div>` },
+        // Different values — not collapsable
+        { code: `<div class="mt:8 mb:16">a</div>` },
+        // Different conditions — not collapsable (mt:8 vs mb:8@sm)
+        { code: `<div class="mt:8 mb:8@sm">a</div>` },
+        // Single longhand — leave alone
+        { code: `<div class="mt:8 bg:white">a</div>` },
+    ],
+    invalid: [
+        {
+            code: `<div class="mt:8 mb:8">a</div>`,
+            output: `<div class="my:8">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            code: `<div class="ml:8 mr:8">a</div>`,
+            output: `<div class="mx:8">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            code: `<div class="mt:8 mr:8 mb:8 ml:8">a</div>`,
+            output: `<div class="m:8">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            code: `<div class="pt:16 pb:16">a</div>`,
+            output: `<div class="py:16">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            // Conditions match → collapse preserves the condition
+            code: `<div class="mt:8@sm mb:8@sm">a</div>`,
+            output: `<div class="my:8@sm">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            // Important suffix preserved
+            code: `<div class="mt:8! mb:8!">a</div>`,
+            output: `<div class="my:8!">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            // 4-side has higher priority than 2-side: only one recommendation per group
+            code: `<div class="bg:white mt:8 mr:8 mb:8 ml:8">a</div>`,
+            output: `<div class="bg:white m:8">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+        {
+            // 3-side: no 4-side match, but mt+mb still collapse to my, leaving ml alone
+            code: `<div class="mt:8 mb:8 ml:8">a</div>`,
+            output: `<div class="my:8 ml:8">a</div>`,
+            errors: [{ messageId: 'recommend' }]
+        },
+    ]
+})


### PR DESCRIPTION
Closes #338.

## Summary

Adds a 4th rule to \`@master/eslint-plugin-css\`: warns (with auto-fix) when a set of long-hand utilities can be collapsed to the equivalent shorthand.

## Initial recommendation set

| Long-hands | Shorthand |
|------------|-----------|
| \`mt mr mb ml\` | \`m\` |
| \`mt mb\` | \`my\` |
| \`ml mr\` | \`mx\` |
| \`pt pr pb pl\` | \`p\` |
| \`pt pb\` | \`py\` |
| \`pl pr\` | \`px\` |
| \`top right bottom left\` | \`inset\` |
| \`top bottom\` | \`inset-y\` |
| \`left right\` | \`inset-x\` |

Strict matching: same value, same conditional-query suffix (\`@sm\`, \`:hover\`), same \`!\` flag. 4-side recommendation runs before 2-side so a fully-bracketed group is collapsed once. Auto-fix uses a single \`replaceTextRange\` over the whole span, avoiding ESLint's "overlapped fix" guard.

Wired into the \`recommended\` config at \`warn\` severity. Easy to extend — the \`RECOMMENDATIONS\` table accepts more entries.

## Bonus fix in resolve-class-node

Building the auto-fix surfaced a pre-existing bug: the LAST class node of a className attribute had \`range[0]\` set to the className value's start instead of the individual class's start. Any rule that sorts class nodes by source position would mis-order. Fixed in the same PR; all 14 existing eslint-plugin test files still pass.

## Testing

- 13 RuleTester cases (valid: already-shorthand / different values / different conditions / single longhand; invalid: 2-side, 4-side, 3-side, conditions, important, mixed with non-axis classes)
- 14/14 plugin test files pass
- \`pnpm lint\` + \`pnpm type-check\` clean