### PR TITLE
Fix(CSS): TypeScript narrow on aliasVariableModeResolver closure

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -387,10 +387,12 @@ export default class MasterCSS {
                     const alpha = aliasResult[2] ?? aliasResult[4]
                     let aliasVariableModeResolver = aliasVariableModeResolvers.get(variable.name)
                     if (!aliasVariableModeResolver) {
-                        aliasVariableModeResolvers.set(variable.name, aliasVariableModeResolver = {})
+                        aliasVariableModeResolver = {}
+                        aliasVariableModeResolvers.set(variable.name, aliasVariableModeResolver)
                     }
-                    aliasVariableModeResolver[mode as string] = () => {
-                        delete aliasVariableModeResolver[mode as string]
+                    const resolver = aliasVariableModeResolver
+                    resolver[mode as string] = () => {
+                        delete resolver[mode as string]
                         if (!alias) return
                         const eachAliasModeVariableResolver = aliasVariableModeResolvers.get(alias)
                         if (eachAliasModeVariableResolver) {


### PR DESCRIPTION
## Summary

Pre-existing strict-TS error in \`packages/core/src/core.ts:resolveVariables\`. The inner closure references an outer \`let\` binding that TypeScript can't prove non-undefined after the if-block assignment.

```ts
let aliasVariableModeResolver = aliasVariableModeResolvers.get(variable.name)
if (!aliasVariableModeResolver) {
    aliasVariableModeResolvers.set(variable.name, aliasVariableModeResolver = {})
}
aliasVariableModeResolver[mode as string] = () => {
    delete aliasVariableModeResolver[mode as string]   // ← TS18048 'possibly undefined'
    ...
}
```

Fix: pull the assignment out of the conditional and capture into a `const`, so the closure references a definitely-defined value.

## Why this matters

Surfaces only when a downstream package (extractor) type-checks core under stricter resolution —`pnpm --filter @master/css-extractor type-check` was failing on every `rc`-based commit.

## Testing

- `tsc --noEmit` passes for core, extractor, and all 17 issue-resolving branches
- 108 core test files still pass; runtime behaviour unchanged (same control flow, just type-narrowed)