### PR TITLE
Test(Language): Grammar tokenization regression tests

### DIFF
--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -5,7 +5,13 @@
         "build": "techor build \"src/**/*.ts\"",
         "dev": "pnpm build --watch",
         "lint": "eslint",
-        "type-check": "tsc --noEmit"
+        "type-check": "tsc --noEmit",
+        "test": "vitest"
+    },
+    "devDependencies": {
+        "@shikijs/langs": "^3.0.0",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.2.0"
     },
     "license": "MIT",
     "description": "The language declaration, TextMate grammars provide syntax highlighting and improved editor integration.",

--- a/packages/language/syntaxes/master-css.injection-class.json
+++ b/packages/language/syntaxes/master-css.injection-class.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-class",
-    "injectionSelector": "L:meta.attribute.class string.quoted",
+    "injectionSelector": "L:meta.attribute.class string.quoted -comment",
     "patterns": [
         {
             "include": "source.master-css"

--- a/packages/language/syntaxes/master-css.injection-react.json
+++ b/packages/language/syntaxes/master-css.injection-react.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-react",
-    "injectionSelector": "L:meta.tag,L:source.mdx",
+    "injectionSelector": "L:meta.tag -comment, L:source.mdx -comment",
     "patterns": [
         {
             "include": "#highlight-class-quoted-double"

--- a/packages/language/syntaxes/master-css.injection-string.json
+++ b/packages/language/syntaxes/master-css.injection-string.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-string",
-    "injectionSelector": "L:meta.embedded.block.master-css.class string.quoted",
+    "injectionSelector": "L:meta.embedded.block.master-css.class string.quoted -comment",
     "patterns": [
         {
             "include": "source.master-css"

--- a/packages/language/syntaxes/master-css.injection-vue.json
+++ b/packages/language/syntaxes/master-css.injection-vue.json
@@ -1,7 +1,7 @@
 {
     "name": "master-css",
     "scopeName": "source.master-css.injection-vue",
-    "injectionSelector": "L:source.vue meta.attribute.directive meta.array.literal string.template",
+    "injectionSelector": "L:source.vue meta.attribute.directive meta.array.literal string.template -comment",
     "patterns": [
         {
             "include": "source.master-css"

--- a/packages/language/syntaxes/master-css.json
+++ b/packages/language/syntaxes/master-css.json
@@ -208,7 +208,7 @@
                     "match": "(?<=(?:[^\\s;:]+:|[@~]|(?:[^\\s;\\:\\|,]+\\())[^\\s;\\:\"'`]*)(\\|)",
                     "captures": {
                         "1": {
-                            "name": "comment.block"
+                            "name": "punctuation.separator.master-css"
                         }
                     }
                 },
@@ -273,7 +273,7 @@
         "master-css-selector": {
             "patterns": [
                 {
-                    "match": "(?<![\\|/])(\\.)(?!\\d)([^\\s;'\"`@:><.\\[\\]_\\+\\(\\),]*)",
+                    "match": "(?<![A-Za-z0-9_\\-\\|/])(\\.)(?!\\d)([^\\s;'\"`@:><.\\[\\]_\\+\\(\\),]*)",
                     "captures": {
                         "1": {
                             "name": "entity.other.attribute-name.class.css"

--- a/packages/language/tests/grammar.test.ts
+++ b/packages/language/tests/grammar.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeAll } from 'vitest'
+import { loadGrammar, tokenize, findToken, hasMcssScope, hasCommentScope } from './setup'
+import type { IGrammar } from 'vscode-textmate'
+
+describe('master-css grammar — TSX host', () => {
+    let grammar: IGrammar
+
+    beforeAll(async () => {
+        ({ grammar } = await loadGrammar('tsx'))
+    })
+
+    test('live className gets master-css fingerprint scopes', () => {
+        const tokens = tokenize(grammar, `<div className="bg:white fg:black">x</div>`)
+        const bg = findToken(tokens, 'bg')
+        if (!bg) throw new Error('bg token not found')
+        expect(hasMcssScope(bg.scopes)).toBe(true)
+        expect(hasCommentScope(bg.scopes)).toBe(false)
+    })
+
+    test('issue #361: line-commented JSX className does NOT get master-css scopes', () => {
+        const tokens = tokenize(grammar, `// const a = <div className="bg:white">x</div>`)
+        const bg = findToken(tokens, 'bg')
+        if (!bg) throw new Error('bg token not found')
+        expect(hasMcssScope(bg.scopes)).toBe(false)
+        expect(hasCommentScope(bg.scopes)).toBe(true)
+    })
+
+    test('issue #361: block-commented JSX className does NOT get master-css scopes', () => {
+        const tokens = tokenize(grammar, `/* const a = <div className="bg:white">x</div> */`)
+        const bg = findToken(tokens, 'bg')
+        if (!bg) throw new Error('bg token not found')
+        expect(hasMcssScope(bg.scopes)).toBe(false)
+        expect(hasCommentScope(bg.scopes)).toBe(true)
+    })
+
+    test('issue #217: `|` separator in className uses punctuation.separator.master-css, not comment.block', () => {
+        const tokens = tokenize(grammar, `<div className="bg:white|red">x</div>`)
+        const pipe = tokens.find(t => t.text === '|')
+        if (!pipe) throw new Error('pipe token not found')
+        // The pipe must NOT be in comment.block (the pre-fix scope) ...
+        expect(pipe.scopes).not.toContain('comment.block')
+        // ... and must carry the new dedicated punctuation scope.
+        expect(pipe.scopes).toContain('punctuation.separator.master-css')
+    })
+
+    test('issue #217: `.png` inside bg:url(/foo.png) is NOT treated as a CSS class selector', () => {
+        const tokens = tokenize(grammar, `<div className="bg:url(/foo.png)|cover">x</div>`)
+        // Look for any token whose text contains `.png` — it must not carry
+        // the class-selector scope (the pre-fix bug).
+        const pngTokens = tokens.filter(t => t.text.includes('png') || t.text.includes('.png'))
+        for (const tok of pngTokens) {
+            expect(tok.scopes).not.toContain('entity.other.attribute-name.class.css')
+        }
+    })
+
+    test('regression: `.btn` after a space is still tokenized as a class selector', () => {
+        const tokens = tokenize(grammar, `<div className="bg:white .btn">x</div>`)
+        const dot = tokens.find(t => t.text === '.')
+        const btn = tokens.find(t => t.text === 'btn')
+        // Either the `.` and `btn` are separate tokens, both carrying the
+        // class-selector scope, or they're merged into `.btn` carrying it.
+        const merged = tokens.find(t => t.text === '.btn')
+        const carriers = [dot, btn, merged].filter(Boolean) as { scopes: string[] }[]
+        expect(carriers.length).toBeGreaterThan(0)
+        expect(carriers.some(t => t.scopes.includes('entity.other.attribute-name.class.css'))).toBe(true)
+    })
+})
+
+describe('master-css grammar — HTML host', () => {
+    let grammar: IGrammar
+
+    beforeAll(async () => {
+        ({ grammar } = await loadGrammar('html'))
+    })
+
+    test('live class attribute gets master-css fingerprint scopes', () => {
+        const tokens = tokenize(grammar, `<div class="bg:white fg:black">x</div>`)
+        const bg = findToken(tokens, 'bg')
+        if (!bg) throw new Error('bg token not found')
+        expect(hasMcssScope(bg.scopes)).toBe(true)
+    })
+
+    test('issue #361: HTML-commented class does NOT get master-css scopes', () => {
+        const tokens = tokenize(grammar, `<!-- <div class="bg:white">x</div> -->`)
+        const bg = findToken(tokens, 'bg')
+        if (!bg) throw new Error('bg token not found')
+        expect(hasMcssScope(bg.scopes)).toBe(false)
+        expect(hasCommentScope(bg.scopes)).toBe(true)
+    })
+})

--- a/packages/language/tests/setup.ts
+++ b/packages/language/tests/setup.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { Registry, INITIAL, type IGrammar } from 'vscode-textmate'
+import { loadWASM, OnigScanner, OnigString } from 'vscode-oniguruma'
+
+const SYNTAX_DIR = resolve(__dirname, '..', 'syntaxes')
+
+let wasmLoaded = false
+async function ensureWasm() {
+    if (wasmLoaded) return
+    // The shipped WASM lives under `vscode-oniguruma/release/onig.wasm`.
+    const wasmPath = require.resolve('vscode-oniguruma/release/onig.wasm')
+    await loadWASM(readFileSync(wasmPath).buffer)
+    wasmLoaded = true
+}
+
+async function loadShikiGrammars(name: string) {
+    // @shikijs/langs ships pre-converted vscode TextMate grammars per language.
+    const mod = await import(`@shikijs/langs/${name}`)
+    const arr = (mod.default ?? mod) as any
+    return Array.isArray(arr) ? arr : [arr]
+}
+
+const masterCssGrammars: Record<string, any> = {
+    'source.master-css': JSON.parse(readFileSync(resolve(SYNTAX_DIR, 'master-css.json'), 'utf8')),
+    'source.master-css.injection-class': JSON.parse(readFileSync(resolve(SYNTAX_DIR, 'master-css.injection-class.json'), 'utf8')),
+    'source.master-css.injection-react': JSON.parse(readFileSync(resolve(SYNTAX_DIR, 'master-css.injection-react.json'), 'utf8')),
+    'source.master-css.injection-vue': JSON.parse(readFileSync(resolve(SYNTAX_DIR, 'master-css.injection-vue.json'), 'utf8')),
+    'source.master-css.injection-string': JSON.parse(readFileSync(resolve(SYNTAX_DIR, 'master-css.injection-string.json'), 'utf8')),
+    'source.master-css.injection-js': JSON.parse(readFileSync(resolve(SYNTAX_DIR, 'master-css.injection-js.json'), 'utf8')),
+}
+
+interface GrammarRegistry {
+    grammar: IGrammar
+}
+
+/**
+ * Build a vscode-textmate Registry that can tokenize the given host language
+ * (e.g. `tsx`, `html`) with all master-css injection grammars applied.
+ */
+export async function loadGrammar(host: 'tsx' | 'html' | 'vue'): Promise<GrammarRegistry> {
+    await ensureWasm()
+    const hostGrammars = await loadShikiGrammars(host)
+
+    const grammars = new Map<string, any>()
+    for (const g of hostGrammars) grammars.set(g.scopeName, g)
+    for (const [scope, g] of Object.entries(masterCssGrammars)) {
+        grammars.set(scope, g)
+    }
+
+    const injections = Object.keys(masterCssGrammars).filter(s => s.includes('injection-'))
+
+    const registry = new Registry({
+        onigLib: Promise.resolve({
+            createOnigScanner: (patterns) => new OnigScanner(patterns),
+            createOnigString: (s) => new OnigString(s),
+        }),
+        loadGrammar: async (scope) => grammars.get(scope) ?? null,
+        getInjections: () => injections,
+    })
+
+    const hostScope = host === 'tsx'
+        ? 'source.tsx'
+        : host === 'html'
+            ? 'text.html.basic'
+            : 'source.vue'
+
+    const grammar = await registry.loadGrammar(hostScope)
+    if (!grammar) throw new Error(`Failed to load host grammar: ${hostScope}`)
+
+    return { grammar }
+}
+
+interface TokenScopeInfo {
+    text: string
+    scopes: string[]
+}
+
+/** Tokenize a single line; returns tokens with text + scope chain. */
+export function tokenize(grammar: IGrammar, line: string): TokenScopeInfo[] {
+    const r = grammar.tokenizeLine(line, INITIAL)
+    return r.tokens.map(t => ({
+        text: line.slice(t.startIndex, t.endIndex),
+        scopes: t.scopes,
+    }))
+}
+
+/** Find the token that contains the given substring in `text`. */
+export function findToken(tokens: TokenScopeInfo[], substring: string): TokenScopeInfo | undefined {
+    return tokens.find(t => t.text.includes(substring))
+}
+
+// Master-css injection emits these distinctive scopes; their presence on a
+// token indicates that the master-css grammar successfully ran on it.
+export const MCSS_FINGERPRINTS = [
+    'support.type.property-name.css',
+    'variable.argument.css',
+    'support.function.misc.css',
+    'punctuation.separator.key-value.css',
+    'punctuation.separator.master-css',
+    'entity.other.attribute-name.class.css',
+]
+
+export function hasMcssScope(scopes: string[]): boolean {
+    return scopes.some(s => MCSS_FINGERPRINTS.includes(s))
+}
+
+export function hasCommentScope(scopes: string[]): boolean {
+    return scopes.some(s => s.startsWith('comment.'))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1448,7 +1448,17 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(rollup@4.44.1)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
 
-  packages/language: {}
+  packages/language:
+    devDependencies:
+      '@shikijs/langs':
+        specifier: ^3.0.0
+        version: 3.7.0
+      vscode-oniguruma:
+        specifier: ^2.0.1
+        version: 2.0.1
+      vscode-textmate:
+        specifier: ^9.2.0
+        version: 9.3.2
 
   packages/language-server:
     dependencies:
@@ -16271,6 +16281,12 @@ packages:
   vscode-languageserver@9.0.1:
     resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
     hasBin: true
+
+  vscode-oniguruma@2.0.1:
+    resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
+
+  vscode-textmate@9.3.2:
+    resolution: {integrity: sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -35532,6 +35548,10 @@ snapshots:
   vscode-languageserver@9.0.1:
     dependencies:
       vscode-languageserver-protocol: 3.17.5
+
+  vscode-oniguruma@2.0.1: {}
+
+  vscode-textmate@9.3.2: {}
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
Adds the missing test infrastructure for \`packages/language\`. Without it, every grammar regex change risked silently breaking syntax highlighting; this PR closes that gap with 8 fixture-based tokenization tests.

Builds on PR #426 (the grammar regex fixes) — without those, the #217 regression cases fail. Recommend merging PR #426 first, then this.

## Changes

- \`vscode-textmate\` + \`vscode-oniguruma\` + \`@shikijs/langs\` as devDeps
- \`tests/setup.ts\` — loads master-css.json + 5 injection grammars, wires shiki-bundled host grammars (TSX/HTML/Vue), exposes \`loadGrammar()\` / \`tokenize()\` / \`findToken()\` helpers
- \`tests/grammar.test.ts\` — 8 fixture cases:
  - live JSX \`className\` and HTML \`class\` attribute fingerprints
  - #361 line/block/HTML-comment exclusion
  - #217 \`|\` carries \`punctuation.separator.master-css\` (not \`comment.block\`)
  - #217 \`.png\` in \`bg:url(/foo.png)\` not class-selector
  - regression: \`.btn\` after a space still tokenizes as class selector

## Testing

8/8 pass on top of PR #426. Lint + type-check clean.