### PR TITLE
Fix(Language): Add language-configuration for comment toggle

### DIFF
--- a/packages/language/src/declaration.ts
+++ b/packages/language/src/declaration.ts
@@ -6,7 +6,8 @@ const declaration = {
     ],
     extensions: [
         '.mcss'
-    ]
+    ],
+    configuration: './syntaxes/language-configuration.json'
 }
 
 export default declaration

--- a/packages/language/syntaxes/language-configuration.json
+++ b/packages/language/syntaxes/language-configuration.json
@@ -1,0 +1,27 @@
+{
+    "comments": {
+        "lineComment": "//",
+        "blockComment": ["/*", "*/"]
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "`", "close": "`", "notIn": ["string", "comment"] }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"],
+        ["`", "`"]
+    ]
+}

--- a/packages/language/tests/language-configuration.test.mjs
+++ b/packages/language/tests/language-configuration.test.mjs
@@ -1,0 +1,34 @@
+// Node-native test (run with `node --test packages/language/tests/language-configuration.test.mjs`).
+// Kept dependency-free so it can run without the package-level vitest setup.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const lcPath = resolve(here, '..', 'syntaxes', 'language-configuration.json')
+const declPath = resolve(here, '..', 'src', 'declaration.ts')
+
+test('language-configuration.json parses as JSON', () => {
+    const raw = readFileSync(lcPath, 'utf8')
+    assert.doesNotThrow(() => JSON.parse(raw))
+})
+
+test('language-configuration exposes line + block comments', () => {
+    const lc = JSON.parse(readFileSync(lcPath, 'utf8'))
+    assert.equal(lc.comments.lineComment, '//', 'lineComment must be // so VS Code can toggle comments inside meta.embedded.block.master-css.class regions of TS/JS host files (issue #361)')
+    assert.deepEqual(lc.comments.blockComment, ['/*', '*/'])
+})
+
+test('language-configuration declares brackets + auto-closing pairs', () => {
+    const lc = JSON.parse(readFileSync(lcPath, 'utf8'))
+    assert.ok(Array.isArray(lc.brackets) && lc.brackets.length >= 3)
+    assert.ok(Array.isArray(lc.autoClosingPairs) && lc.autoClosingPairs.length >= 3)
+    assert.ok(Array.isArray(lc.surroundingPairs) && lc.surroundingPairs.length >= 3)
+})
+
+test('declaration.ts references the language-configuration', () => {
+    const decl = readFileSync(declPath, 'utf8')
+    assert.match(decl, /configuration:\s*['"]\.\/syntaxes\/language-configuration\.json['"]/)
+})

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -68,7 +68,8 @@
                 ],
                 "extensions": [
                     ".mcss"
-                ]
+                ],
+                "configuration": "./syntaxes/language-configuration.json"
             }
         ],
         "grammars": [


### PR DESCRIPTION
## Summary

`packages/vscode/package.json`'s `contributes.languages` entry for `master-css` had no `configuration` field — there was no `language-configuration.json`. As a result, when the cursor sits inside `meta.embedded.block.master-css.class` (the embedded scope created by `master-css.injection-react.json` / `injection-js.json` / etc. for `className={classNames(...)}` etc.), VS Code asks the `master-css` language for comment characters, gets nothing, and the **Toggle Line Comment** shortcut becomes a no-op. That is the exact \"doesn't work at all\" symptom in #361.

## Changes

- `packages/language/syntaxes/language-configuration.json` (new) — `lineComment: \"//\"`, `blockComment: [\"/*\", \"*/\"]`, plus standard `brackets`, `autoClosingPairs`, `surroundingPairs`. The comment characters are JS-syntactic on purpose: when the cursor is inside an embedded `master-css` block within a TS/JS host file (the situation in the issue's screenshots), toggling produces a valid host-language comment.
- `packages/language/src/declaration.ts` — adds `configuration: './syntaxes/language-configuration.json'`. `packages/vscode/generate.ts` propagates `declaration` verbatim into the language entry, so this is the single source of truth.
- `packages/vscode/package.json` — pre-applies the same field so `pnpm generate` is a no-op after merge (and CI checks that compare hand-written vs generated stay green). Diff verified by re-running the generate logic locally — the rendered output matches byte-for-byte.
- `packages/language/tests/language-configuration.test.mjs` (new) — 4 dependency-free `node --test` cases: JSON parses, line+block comments are present, brackets/auto-closing pairs are non-empty, and `declaration.ts` references the file. Runs as `node --test packages/language/tests/language-configuration.test.mjs`. No vitest deps added so this doesn't conflict with the separate `feat/language-grammar-tests` branch that introduces vitest to this package.

## Why this scope

The issue's second screenshot (\"works but syntax highlighting broken\") is a separate grammar concern — fixing the missing language-configuration is necessary regardless and is the cleanly-isolatable change. Keeping this PR surgical means it can land independently.

## Test plan

- [x] `node --test packages/language/tests/language-configuration.test.mjs` — 4/4 pass
- [x] `tsx -e` re-render of `generate.ts`'s language emission matches the hand-applied edit in `packages/vscode/package.json`
- [ ] Manual VS Code verification: install local VSIX, place cursor inside `className={classNames(\"bg:white\", \"fg:black\")}`, press Cmd/Ctrl+/, observe both lines toggle correctly

Closes #361