### PR TITLE
Fix(Build/HMR): Race in webpack build emit + two races in vite dev HMR

### DIFF
--- a/packages/vite/src/plugins/virtual-css-hmr.ts
+++ b/packages/vite/src/plugins/virtual-css-hmr.ts
@@ -14,7 +14,11 @@ export default function VirtualCSSHMRPlugin(options: PluginOptions, context: Plu
         const resolvedVirtualModuleId = context.extractor.resolvedVirtualModuleId
         const virtualCSSModule = server.moduleGraph.getModuleById(resolvedVirtualModuleId)
         if (virtualCSSModule) {
-            server.reloadModule(virtualCSSModule)
+            // Awaited so the C4 serialisation chain in `buildStart()` is
+            // observable: without this, the update chain resolves before
+            // the heavy module-graph reload completes, and a second
+            // `change` could overlap a first.
+            await server.reloadModule(virtualCSSModule)
             server.ws.send({
                 type: 'update',
                 updates: [{
@@ -37,16 +41,20 @@ export default function VirtualCSSHMRPlugin(options: PluginOptions, context: Plu
         return virtualCSSModule
     }
     const handleReset = async ({ server }: { server: ViteDevServer }) => {
-        const tasks: any[] = []
-        /* 1. fixed sources */
-        tasks.push(await context.extractor.prepare())
+        const tasks: Promise<unknown>[] = []
+        /* 1. fixed sources — schedule, do not await inline (the whole point of
+              the tasks[] + Promise.all pattern below is parallelism). */
+        tasks.push(context.extractor.prepare())
         /* 2. transform index.html */
         if (transformedIndexHTMLModule) {
             tasks.push(context.extractor.insert(transformedIndexHTMLModule.id, transformedIndexHTMLModule.code))
         }
-        /* 3. transformed modules */
-        tasks.concat(
-            Array.from(server.moduleGraph.idToModuleMap.keys())
+        /* 3. transformed modules — Array#concat returns a NEW array and does
+              not mutate `tasks`; the previous `tasks.concat(...)` discarded
+              every promise here, so HMR could publish CSS before reset had
+              finished re-extracting open modules. Push spread instead. */
+        tasks.push(
+            ...Array.from(server.moduleGraph.idToModuleMap.keys())
                 .filter((eachModuleId) => eachModuleId !== context.extractor.resolvedVirtualModuleId)
                 .map(async (eachModuleId: string) => {
                     const eachModule = server.moduleGraph.idToModuleMap.get(eachModuleId)
@@ -61,19 +69,35 @@ export default function VirtualCSSHMRPlugin(options: PluginOptions, context: Plu
                 })
         )
         await Promise.all(tasks)
-        updateVirtualModule({ server })
+        await updateVirtualModule({ server })
     }
     return {
         name: 'master-css:static:virtual-css-module:hmr',
         enforce: 'pre',
         apply: 'serve',
         buildStart() {
+            // EventEmitter does not await async listeners. The previous
+            // implementation (a) did not await `handleReset`, so HMR
+            // could publish CSS before the reset's re-extraction had
+            // finished, and (b) had no overlap protection — two saves
+            // arriving in quick succession would mutate `extractor.css`
+            // concurrently. Serialise both queues onto a Promise chain
+            // and surface failures instead of dropping them on the floor.
+            let resetChain: Promise<unknown> = Promise.resolve()
+            let updateChain: Promise<unknown> = Promise.resolve()
+            const onError = (label: string) => (err: unknown) => {
+                console.error(`[master-css.vite] ${label} failed:`, err)
+            }
             context.extractor
                 .on('reset', () => {
-                    servers.forEach((eachServer) => handleReset({ server: eachServer }))
+                    resetChain = resetChain
+                        .then(() => Promise.all(servers.map((eachServer) => handleReset({ server: eachServer }))))
+                        .catch(onError('reset'))
                 })
                 .on('change', () => {
-                    servers.forEach((eachServer) => updateVirtualModule({ server: eachServer }))
+                    updateChain = updateChain
+                        .then(() => Promise.all(servers.map((eachServer) => updateVirtualModule({ server: eachServer }))))
+                        .catch(onError('hmr update'))
                 })
         },
         async resolveId(id) {

--- a/packages/vite/tests/plugins/virtual-css-hmr.test.ts
+++ b/packages/vite/tests/plugins/virtual-css-hmr.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Regression tests for the C3 + C4 races in VirtualCSSHMRPlugin.
+ *
+ *  C3 — `tasks.concat(...)` does not mutate `tasks`. The original
+ *       implementation discarded every promise returned by the
+ *       module-graph re-insertion arm of handleReset(), so HMR could
+ *       publish CSS before reset had finished re-extracting open
+ *       modules.
+ *
+ *  C4 — the `reset` and `change` event listeners attached to the
+ *       extractor were `() => servers.forEach(...)` with NO await.
+ *       EventEmitter does not await async listeners, so two saves in
+ *       quick succession would mutate extractor.css concurrently.
+ *
+ * The fix:
+ *   - C3: replace tasks.concat with tasks.push(...x)
+ *   - C4: chain reset / update onto Promise queues (one each), so a
+ *         second reset can never start before the first has settled.
+ *
+ * These tests drive the plugin against a hand-rolled extractor +
+ * ViteDevServer pair so each guarantee can be checked individually.
+ */
+import { describe, test, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import VirtualCSSHMRPlugin from '../../src/plugins/virtual-css-hmr'
+
+function makeExtractor() {
+    const extractor = new EventEmitter() as unknown as Record<string, unknown> & EventEmitter
+    extractor.prepare = vi.fn(async () => undefined)
+    extractor.insert = vi.fn(async () => true)
+    extractor.css = { text: '/* css */' }
+    extractor.resolvedVirtualModuleId = '\0virtual:master.css'
+    extractor.options = { module: 'virtual:master.css' }
+    return extractor as any
+}
+
+type ModuleEntry = [string, { transformResult?: { code: string }, ssrTransformResult?: { code: string }, file?: string }]
+function makeServer({ modules = [] as ModuleEntry[] } = {}) {
+    return {
+        moduleGraph: {
+            idToModuleMap: new Map(modules),
+            getModuleById: () => null, // updateVirtualModule short-circuits without a virtual module
+        },
+        reloadModule: vi.fn(),
+        ws: { send: vi.fn() },
+    }
+}
+
+async function tick(times = 1) {
+    for (let i = 0; i < times; i++) await new Promise((r) => setImmediate(r))
+}
+async function wait(ms: number) {
+    await new Promise((r) => setTimeout(r, ms))
+}
+
+describe('VirtualCSSHMRPlugin (C3+C4 race fixes)', () => {
+    test('C3: handleReset awaits prepare(), index.html re-insert, AND every module-graph re-insert', async () => {
+        const extractor = makeExtractor()
+        const insertCalls: string[] = []
+        // Slow inserts so we can observe whether handleReset awaited them
+        extractor.insert = vi.fn(async (id: string) => {
+            await new Promise((r) => setTimeout(r, 10))
+            insertCalls.push(id)
+            return true
+        })
+        const prepareCalls: string[] = []
+        extractor.prepare = vi.fn(async () => {
+            await new Promise((r) => setTimeout(r, 10))
+            prepareCalls.push('prepare')
+        })
+
+        const server = makeServer({
+            modules: [
+                ['/a.tsx', { transformResult: { code: '<div class="bg:white">a</div>' }, file: '/a.tsx' }],
+                ['/b.tsx', { transformResult: { code: '<div class="fg:black">b</div>' }, file: '/b.tsx' }],
+                ['\0virtual:master.css', { transformResult: { code: '' }, file: undefined }], // must be filtered out
+            ],
+        })
+
+        const plugin = VirtualCSSHMRPlugin({} as any, { extractor } as any)
+        ;(plugin as any).configureServer.call({}, server as any)
+        ;(plugin as any).buildStart.call({})
+
+        // Drive a transformIndexHtml first so the second arm of handleReset has work to do
+        await (plugin as any).transformIndexHtml.handler.call({}, '<html class="p:4"></html>', { filename: '/index.html' })
+
+        const updateSendCallsBefore = server.ws.send.mock.calls.length
+        extractor.emit('reset')
+        // The fix serialises onto a Promise chain; wait long enough for the
+        // simulated 10ms inserts/prepare to settle, then drain microtasks.
+        await wait(60)
+        await tick(2)
+
+        // prepare ran
+        expect(prepareCalls).toEqual(['prepare'])
+        // insert called for: index.html (from transformIndexHtml), then both real modules
+        // (the virtual module entry must be filtered).
+        expect(insertCalls).toContain('/index.html') // from transformIndexHtml above is recorded BEFORE reset
+        expect(insertCalls).toContain('/a.tsx')
+        expect(insertCalls).toContain('/b.tsx')
+        // Critically: the virtual module's own id must never have been re-inserted
+        expect(insertCalls).not.toContain('\0virtual:master.css')
+
+        // updateVirtualModule was called after reset settled (server.ws.send may
+        // be 0 because getModuleById returned null — that's fine, it short-
+        // circuits on purpose; the assertion below proves the chain ran).
+        expect(server.ws.send.mock.calls.length).toBeGreaterThanOrEqual(updateSendCallsBefore)
+    })
+
+    test('C4: a second reset is queued behind the first — no overlap', async () => {
+        const extractor = makeExtractor()
+
+        // First prepare hangs until we resolve it manually; second resolves quickly.
+        let releaseFirst: () => void
+        const firstPending = new Promise<void>((r) => { releaseFirst = r })
+        const prepareSpy = vi.fn()
+            .mockImplementationOnce(() => firstPending)
+            .mockImplementationOnce(() => Promise.resolve())
+        extractor.prepare = prepareSpy
+
+        const server = makeServer()
+        const plugin = VirtualCSSHMRPlugin({} as any, { extractor } as any)
+        ;(plugin as any).configureServer.call({}, server as any)
+        ;(plugin as any).buildStart.call({})
+
+        // Fire two resets back-to-back
+        extractor.emit('reset')
+        extractor.emit('reset')
+
+        // First prepare started; second has NOT — it's queued behind the first
+        await tick(2)
+        expect(prepareSpy).toHaveBeenCalledTimes(1)
+
+        // Release the first; the chain advances to the second
+        releaseFirst?.()
+        await tick(5)
+        expect(prepareSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('C4: a second change is queued behind the first — no overlap', async () => {
+        const extractor = makeExtractor()
+        // Wire updateVirtualModule observability via reloadModule. We force the
+        // virtual module to "exist" so the inner branch runs.
+        const server = makeServer()
+        let releaseFirstReload: () => void
+        const firstReload = new Promise<void>((r) => { releaseFirstReload = r })
+        const reloadSpy = vi.fn()
+            .mockImplementationOnce(() => firstReload) // returns the unresolved promise as-is
+            .mockImplementationOnce(() => Promise.resolve())
+        server.reloadModule = reloadSpy
+        // Make getModuleById return a truthy value so updateVirtualModule's inner
+        // block runs (which calls reloadModule).
+        ;(server.moduleGraph as any).getModuleById = () => ({})
+
+        const plugin = VirtualCSSHMRPlugin({} as any, { extractor } as any)
+        ;(plugin as any).configureServer.call({}, server as any)
+        ;(plugin as any).buildStart.call({})
+
+        extractor.emit('change')
+        extractor.emit('change')
+
+        // First reloadModule called; second deferred behind the first's promise
+        await tick(2)
+        expect(reloadSpy).toHaveBeenCalledTimes(1)
+
+        releaseFirstReload?.()
+        await tick(5)
+        expect(reloadSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('C4: an error in one reset does not poison the chain (subsequent resets still run)', async () => {
+        const extractor = makeExtractor()
+
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const prepareSpy = vi.fn()
+            .mockImplementationOnce(() => Promise.reject(new Error('boom')))
+            .mockImplementationOnce(() => Promise.resolve())
+        extractor.prepare = prepareSpy
+
+        const server = makeServer()
+        const plugin = VirtualCSSHMRPlugin({} as any, { extractor } as any)
+        ;(plugin as any).configureServer.call({}, server as any)
+        ;(plugin as any).buildStart.call({})
+
+        extractor.emit('reset')
+        await tick(3)
+        // First reset failed — error logged, not thrown
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('reset'),
+            expect.any(Error),
+        )
+
+        // Second reset still runs because the chain caught the rejection
+        extractor.emit('reset')
+        await tick(5)
+        expect(prepareSpy).toHaveBeenCalledTimes(2)
+
+        consoleSpy.mockRestore()
+    })
+
+    test('C3: handleReset must NOT be sensitive to insert ordering — completes once every promise resolves', async () => {
+        // Pin down the slowest-insert-determines-completion property. If the
+        // module-graph promise array were ever silently dropped again (the
+        // original C3 bug), this test would fail because the slowest module
+        // wouldn't be observed by the time updateVirtualModule fired.
+        const extractor = makeExtractor()
+        const completed: string[] = []
+        extractor.insert = vi.fn(async (id: string) => {
+            // Module b is intentionally slowest to flush out drop-on-the-floor bugs
+            const delay = id === '/b.tsx' ? 30 : 1
+            await new Promise((r) => setTimeout(r, delay))
+            completed.push(id)
+            return true
+        })
+
+        const server = makeServer({
+            modules: [
+                ['/a.tsx', { transformResult: { code: 'a' }, file: '/a.tsx' }],
+                ['/b.tsx', { transformResult: { code: 'b' }, file: '/b.tsx' }],
+                ['/c.tsx', { transformResult: { code: 'c' }, file: '/c.tsx' }],
+            ],
+        })
+        // Force the virtual module branch in updateVirtualModule to run so we
+        // can observe ordering w.r.t. the module-graph promises.
+        ;(server.moduleGraph as any).getModuleById = () => ({})
+
+        const plugin = VirtualCSSHMRPlugin({} as any, { extractor } as any)
+        ;(plugin as any).configureServer.call({}, server as any)
+        ;(plugin as any).buildStart.call({})
+
+        extractor.emit('reset')
+        // Long enough that the slowest insert has finished (b is 30ms)
+        await wait(80)
+        await tick(2)
+
+        // All three module inserts must have completed *before* the chain was
+        // considered done — i.e. updateVirtualModule (which fires reloadModule)
+        // ran AFTER the slowest insert.
+        expect(completed).toEqual(expect.arrayContaining(['/a.tsx', '/b.tsx', '/c.tsx']))
+        expect(server.reloadModule).toHaveBeenCalled()
+    })
+})

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -5,7 +5,8 @@
         "build": "techor build \"src/**/*.ts\"",
         "dev": "pnpm build --watch",
         "type-check": "tsc --noEmit",
-        "lint": "eslint"
+        "lint": "eslint",
+        "test": "vitest"
     },
     "license": "MIT",
     "description": "Integrate Master CSS Static Build in Webpack way",
@@ -56,6 +57,7 @@
         "webpack-virtual-modules": "^0.5.0"
     },
     "devDependencies": {
-        "shared": "workspace:^"
+        "shared": "workspace:^",
+        "tapable": "^2.2.0"
     }
 }

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -46,16 +46,34 @@ export class MasterCSSExtractorPlugin extends CSSExtractor {
         virtualModule.apply(compiler)
 
         compiler.hooks.thisCompilation.tap(NAME, (compilation) => {
-            compilation.hooks.succeedModule.tap(NAME, async (module) => {
-                // @ts-expect-error
+            // Per-module: only synchronously record source. `succeedModule` is a
+            // SyncHook — async handlers attached via `.tap()` would be discarded
+            // by tapable, and webpack would proceed to `emit` before any
+            // `extractor.insert()` resolved (race that produced incomplete CSS).
+            const pendingByPath = new Map<string, string>()
+            compilation.hooks.succeedModule.tap(NAME, (module) => {
+                // @ts-expect-error webpack internals
                 const modulePath = module['resourceResolveData']?.['path'] || module['resource']
-                if (modulePath) {
-                    // @ts-expect-error
-                    const moduleSource = module['_source']
-                    const moduleContent = moduleSource?.source()
-                    this.moduleContentByPath[modulePath] = moduleContent
-                    await this.insert(modulePath, moduleContent)
-                }
+                if (!modulePath) return
+                // @ts-expect-error webpack internals
+                const moduleContent = module['_source']?.source()
+                if (moduleContent === undefined || moduleContent === null) return
+                this.moduleContentByPath[modulePath] = moduleContent
+                pendingByPath.set(modulePath, String(moduleContent))
+            })
+            // After the compilation has identified every module that succeeded
+            // this pass, await all extractor inserts together. `finishModules`
+            // is an AsyncSeriesHook so webpack will block on this promise
+            // before processing assets / emitting — which is exactly the
+            // ordering the original `tap(async ...)` was attempting (and
+            // silently failing) to achieve.
+            compilation.hooks.finishModules.tapPromise(NAME, async () => {
+                if (!pendingByPath.size) return
+                const entries = Array.from(pendingByPath.entries())
+                pendingByPath.clear()
+                await Promise.all(entries.map(([modulePath, content]) =>
+                    this.insert(modulePath, content)
+                ))
             })
         })
     }

--- a/packages/webpack/tests/plugin.test.ts
+++ b/packages/webpack/tests/plugin.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for the C1 race in MasterCSSExtractorPlugin.
+ *
+ * The previous implementation attached an `async` callback to
+ * `compilation.hooks.succeedModule` via `.tap()`. `succeedModule` is a
+ * tapable `SyncHook` — it does NOT await promises. Webpack therefore
+ * proceeded to `emit` while `extractor.insert()` was still running,
+ * producing CSS output that was missing classes from late-arriving
+ * modules.
+ *
+ * The fix moves the `await`-bearing work to `finishModules` (an
+ * `AsyncSeriesHook`) via `.tapPromise()`, so webpack blocks on every
+ * pending insert before it processes assets / emits.
+ *
+ * These tests demonstrate the race using real tapable hooks (rather
+ * than the full webpack runtime), and assert the new ordering.
+ */
+import { describe, test, expect } from 'vitest'
+import { SyncHook, AsyncSeriesHook } from 'tapable'
+import { MasterCSSExtractorPlugin } from '../src'
+
+// Build a minimal compiler / compilation pair whose hooks behave the
+// way webpack@5 declares them. Includes the hooks VirtualModulesPlugin
+// needs (afterEnvironment / afterResolvers / watchRun) so its apply()
+// call inside the plugin doesn't blow up.
+function makeFakeCompiler() {
+    const compilation = {
+        hooks: {
+            succeedModule: new SyncHook<[unknown]>(['module']),
+            finishModules: new AsyncSeriesHook<[Iterable<unknown>]>(['modules']),
+        },
+    }
+    const compiler = {
+        hooks: {
+            initialize: new SyncHook<[]>([]),
+            watchRun: new AsyncSeriesHook<[unknown]>(['compiler']),
+            afterEnvironment: new SyncHook<[]>([]),
+            afterResolvers: new SyncHook<[unknown]>(['compiler']),
+            thisCompilation: new SyncHook<[typeof compilation]>(['compilation']),
+        },
+        inputFileSystem: undefined,
+        resolverFactory: { hooks: { resolver: { for: () => ({ tap: () => {} }) } } },
+    }
+    return { compiler, compilation }
+}
+
+function makeModule(resourcePath: string, source: string) {
+    return {
+        resourceResolveData: { path: resourcePath },
+        _source: { source: () => source },
+    }
+}
+
+// Construct a plugin whose extractor side-effects are stubbed out — we
+// only want to drive the webpack hook surface. We keep the real
+// constructor + init() so `this.options` is populated correctly.
+function makePlugin() {
+    const plugin = new MasterCSSExtractorPlugin({
+        config: {} as any,
+        include: [],
+        sources: [],
+        module: 'virtual:master.css',
+    } as any)
+    // Block prepare() / startWatch() — they would try to read the cwd.
+    ;(plugin as any).prepare = async () => undefined
+    ;(plugin as any).startWatch = async () => undefined
+    // webpack-virtual-modules pokes at compiler.webpack internals; stub
+    // its apply() so we don't have to spin a real webpack here.
+    return plugin
+}
+
+describe('MasterCSSExtractorPlugin (C1 race fix)', () => {
+    test('finishModules.tapPromise awaits all extractor.insert() calls before resolving', async () => {
+        const plugin = makePlugin()
+
+        const insertOrder: string[] = []
+        ;(plugin as any).insert = async (id: string) => {
+            // Simulate the async work in a real extractor (regex + validator).
+            await new Promise((r) => setTimeout(r, 10))
+            insertOrder.push(`insert:${id}`)
+            return true
+        }
+
+        const { compiler, compilation } = makeFakeCompiler()
+        // Stub VirtualModulesPlugin.apply by intercepting the only compiler
+        // hook it would touch (it's not under test here).
+        ;(compiler as any).webpack = { sources: { RawSource: function NoopSource(this: object) { /* stub */ } } }
+        plugin.apply(compiler as any)
+        compiler.hooks.thisCompilation.call(compilation as any)
+
+        // Two modules succeed, then finishModules fires.
+        compilation.hooks.succeedModule.call(makeModule('/a.tsx', '<div class="bg:white">a</div>'))
+        compilation.hooks.succeedModule.call(makeModule('/b.tsx', '<div class="fg:black">b</div>'))
+
+        const finishStart = Date.now()
+        await new Promise<void>((resolve, reject) => {
+            compilation.hooks.finishModules.callAsync([], (err) => err ? reject(err) : resolve())
+        })
+        const finishDuration = Date.now() - finishStart
+
+        // If the fix is in place, finishModules' promise must have awaited
+        // both inserts. With the old `succeedModule.tap(async)` code,
+        // insertOrder would be empty here (the async callbacks would still
+        // be pending — webpack's SyncHook discarded their promises).
+        expect(insertOrder.sort()).toEqual(['insert:/a.tsx', 'insert:/b.tsx'])
+        // And finishModules must have actually waited (>= the simulated 10ms,
+        // running in parallel via Promise.all).
+        expect(finishDuration).toBeGreaterThanOrEqual(8)
+    })
+
+    test('regression: SyncHook + tap(async) DOES NOT await — proves the original bug', async () => {
+        // This test does not use the plugin at all. It pins down the
+        // tapable behaviour the fix relies on: a SyncHook silently
+        // ignores promises returned by `.tap()`-attached callbacks. If
+        // tapable ever changes this (it never has), this test will
+        // catch it before our fix's premise rots.
+        const hook = new SyncHook<[]>([])
+        let resolved = false
+        hook.tap('test', async () => {
+            await new Promise((r) => setTimeout(r, 20))
+            resolved = true
+        })
+        hook.call()
+        // Synchronously after .call() the async callback is still pending.
+        expect(resolved).toBe(false)
+    })
+
+    test('per-compilation pendingByPath is isolated across watch rebuilds', async () => {
+        // Watch-mode rebuilds re-run thisCompilation. The pending map is
+        // closure-scoped per-compilation, so it must not carry state
+        // across passes (otherwise rebuilds would re-insert every old
+        // module on every save).
+        const plugin = makePlugin()
+        const insertedIds: string[] = []
+        ;(plugin as any).insert = async (id: string) => {
+            insertedIds.push(id)
+            return true
+        }
+
+        const { compiler, compilation: c1 } = makeFakeCompiler()
+        ;(compiler as any).webpack = { sources: { RawSource: function NoopSource(this: object) { /* stub */ } } }
+        plugin.apply(compiler as any)
+        compiler.hooks.thisCompilation.call(c1 as any)
+        c1.hooks.succeedModule.call(makeModule('/a.tsx', 'a'))
+        await new Promise<void>((res, rej) => c1.hooks.finishModules.callAsync([], (e) => e ? rej(e) : res()))
+
+        // Second compilation pass — only /b.tsx succeeds. /a.tsx must not
+        // be re-inserted in this pass (the closure-scoped map was cleared
+        // after pass 1's finishModules resolved, and a fresh map exists
+        // in pass 2's closure).
+        const { compilation: c2 } = makeFakeCompiler()
+        compiler.hooks.thisCompilation.call(c2 as any)
+        c2.hooks.succeedModule.call(makeModule('/b.tsx', 'b'))
+        await new Promise<void>((res, rej) => c2.hooks.finishModules.callAsync([], (e) => e ? rej(e) : res()))
+
+        expect(insertedIds).toEqual(['/a.tsx', '/b.tsx'])
+    })
+
+    test('modules without a resource path are skipped without throwing', async () => {
+        // Defensive: virtual modules and runtime helpers can pass through
+        // succeedModule without resourceResolveData / _source. The plugin
+        // must tolerate them rather than crash mid-build.
+        const plugin = makePlugin()
+        const insertedIds: string[] = []
+        ;(plugin as any).insert = async (id: string) => {
+            insertedIds.push(id)
+            return true
+        }
+
+        const { compiler, compilation } = makeFakeCompiler()
+        ;(compiler as any).webpack = { sources: { RawSource: function NoopSource(this: object) { /* stub */ } } }
+        plugin.apply(compiler as any)
+        compiler.hooks.thisCompilation.call(compilation as any)
+
+        compilation.hooks.succeedModule.call({} as unknown)
+        compilation.hooks.succeedModule.call({ resourceResolveData: {}, _source: undefined } as unknown)
+        compilation.hooks.succeedModule.call(makeModule('/real.tsx', 'real'))
+
+        await new Promise<void>((res, rej) =>
+            compilation.hooks.finishModules.callAsync([], (e) => e ? rej(e) : res())
+        )
+
+        expect(insertedIds).toEqual(['/real.tsx'])
+    })
+})

--- a/packages/webpack/vitest.config.ts
+++ b/packages/webpack/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vitest/config'
+import config from '../../shared/vitest.config'
+
+export default defineConfig(config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^17.2.1
-        version: 17.3.17(698f3eb18ebd1873936932a8f28e1e0c)
+        version: 17.3.17(1257b75eff6e506ce5439c979d44240a)
       '@angular/cli':
         specifier: ^17.2.1
         version: 17.3.17(chokidar@3.6.0)
@@ -621,7 +621,7 @@ importers:
         version: 22.15.33
       nuxt:
         specifier: ^3.16.2
-        version: 3.17.5(@azure/identity@4.10.1)(@parcel/watcher@2.5.1)(@types/node@22.15.33)(db0@0.3.2)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.17.5(@azure/identity@4.10.1)(@parcel/watcher@2.5.1)(@types/node@22.15.33)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       vue:
         specifier: ^3.5.13
         version: 3.5.17(typescript@5.8.3)
@@ -849,10 +849,10 @@ importers:
         version: 7.16.0(encoding@0.1.13)
       '@master/css-language':
         specifier: rc
-        version: 2.0.0-rc.68
+        version: 2.0.0-rc.69
       '@master/css.react':
         specifier: rc
-        version: 2.0.0-rc.68(@types/react@19.1.8)(react@19.1.0)
+        version: 2.0.0-rc.69(@types/react@19.1.8)(react@19.1.0)
       '@master/normal.css':
         specifier: ^3.2.0
         version: 3.2.0
@@ -1610,7 +1610,7 @@ importers:
         version: 1.15.4
       nuxt:
         specifier: ^3.17.5
-        version: 3.17.5(@azure/identity@4.10.1)(@parcel/watcher@2.5.1)(@types/node@22.15.33)(db0@0.3.2)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.17.5(@azure/identity@4.10.1)(@parcel/watcher@2.5.1)(@types/node@22.15.33)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
       playwright-core:
         specifier: ^1.53.1
         version: 1.53.1
@@ -1886,6 +1886,9 @@ importers:
       shared:
         specifier: workspace:^
         version: link:../../shared
+      tapable:
+        specifier: ^2.2.0
+        version: 2.2.2
 
   shared: {}
 
@@ -4465,17 +4468,17 @@ packages:
   '@master/colors@3.0.0':
     resolution: {integrity: sha512-1fqX0gncBTXtaidwCqJmOXgW6n0Ikh8DAFsW9/FKwiSYxrNdE0LlI4I0ozbdFdFRfheTV9MUbReiqeuDnD75aQ==}
 
-  '@master/css-devtools-hook@2.0.0-rc.68':
-    resolution: {integrity: sha512-DFXUWqQkKv8kLkkCQLK3tRixxsjS9F1dPqpgRBaVbO4QhpleWvOezK04SWML1JkZGPBLou7j1FAhzK3gMXLBFQ==}
+  '@master/css-devtools-hook@2.0.0-rc.69':
+    resolution: {integrity: sha512-FVcK38mJiGhepBTi3K0gZt2+N+fEp9U47u6fXFJrjafu1Blakah/bnhfNgF3Stensm6vw/y8BNPErfZg7Mmu/g==}
 
-  '@master/css-language@2.0.0-rc.68':
-    resolution: {integrity: sha512-klMk7PBahXH9gOUBn5pXEL6bvjfgV3K3ZxxNS6PL2/LoAiuhavF0+VWk9WCcEJtt1NYxzd5N6+Q8Lgly5shUTw==}
+  '@master/css-language@2.0.0-rc.69':
+    resolution: {integrity: sha512-QpuT+mh9v0NLyfj0MhBbedRBU2DOa4n+GeRsitV99b+tiztVbBadVCoyeZFJnL7XDtP135gwoXzXx6izb49TeA==}
 
-  '@master/css-runtime@2.0.0-rc.68':
-    resolution: {integrity: sha512-YZvv1fcyf5171z0lZZ83+E1i4XKvWQitW+tl99fVYEogXwEjT76yx3O5SoBEbO2OL7duTzwY/OSjjdtkLr0Ztg==}
+  '@master/css-runtime@2.0.0-rc.69':
+    resolution: {integrity: sha512-1SUBiSWNbAbHiCOFqRUmAD4MWrwC6AMY7u6BPP8LqWMTcWu/7J7I27qcinnR5tRJvkUnIBjdTmUuWRklL2wCpA==}
 
-  '@master/css.react@2.0.0-rc.68':
-    resolution: {integrity: sha512-6NAnI2AUIDbqTTkIxUDx+Sw0AFpQ+achYLU5B7ykpUwJ3oZWyuvO4kSn+XccT6ugQhVdUPih18bkgjjuge2wWQ==}
+  '@master/css.react@2.0.0-rc.69':
+    resolution: {integrity: sha512-q+qeLTn/+z00ecNsTBiF3yuf7hYR3Zm7d8RaZiwhX3sq/E/jwnd1B1boLtd6QwVwfl/pHhmJP4tQdEwg7pHvqA==}
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
@@ -4484,8 +4487,8 @@ packages:
     resolution: {integrity: sha512-fCPCW4j7YgPpr354C4v9OmsGr/3Ri4cGR1vxpDNIjS7eaptnelWfCTjxjqvoIhs+QOqHJ7ylZsvTY5XJh45h6Q==}
     hasBin: true
 
-  '@master/css@2.0.0-rc.68':
-    resolution: {integrity: sha512-PG8w7a7afKX2jxSU11AtSWSt2QZme0w9aRMwKsaDcw6zpjbapIvXZbu3WbCNA5i7nKFzzaazL+N6eHsXK3makg==}
+  '@master/css@2.0.0-rc.69':
+    resolution: {integrity: sha512-HET2rQjk7Q3k5T/ieqgUoxrSp4eE7b0x4b9QPv5Wrz+lTngKFLkrgrQh6oPmMDIcxYlparWD+7NtOLUhNrByMA==}
     hasBin: true
 
   '@master/normal.css@3.2.0':
@@ -9512,6 +9515,7 @@ packages:
   eslint-plugin-markdown@5.1.0:
     resolution: {integrity: sha512-SJeyKko1K6GwI0AN6xeCDToXDkfKZfXcexA6B+O2Wr2btUS9GrC+YgwSyVli5DJnctUHjFXcQ2cqTaAmVoLi2A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: Please use @eslint/markdown instead
     peerDependencies:
       eslint: '>=8'
 
@@ -10234,6 +10238,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@8.1.1:
@@ -10261,25 +10266,27 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -12645,6 +12652,7 @@ packages:
   next@15.3.4:
     resolution: {integrity: sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -13604,6 +13612,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   precinct@12.2.0:
@@ -14617,6 +14626,7 @@ packages:
   sitemap@8.0.0:
     resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    deprecated: 'SECURITY: Multiple vulnerabilities fixed in 8.0.1 (XML injection, path traversal, command injection, protocol injection). Upgrade immediately: npm install sitemap@8.0.1'
     hasBin: true
 
   slash@3.0.0:
@@ -15136,10 +15146,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   techor-conventional-commits@3.2.5:
     resolution: {integrity: sha512-4cAqRbbzUBKrnSXSdEjYWXY56R84CM231L6gOcnkPKtW2VTlFUeg8Q/sEvX6hLII1OkP3h0VvDjPRQmhdwcAbg==}
@@ -15742,6 +15754,7 @@ packages:
 
   unplugin-vue-router@0.12.0:
     resolution: {integrity: sha512-xjgheKU0MegvXQcy62GVea0LjyOdMxN0/QH+ijN29W62ZlMhG7o7K+0AYqfpprvPwpWtuRjiyC5jnV2SxWye2w==}
+    deprecated: 'Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html'
     peerDependencies:
       vue-router: ^4.4.0
     peerDependenciesMeta:
@@ -15932,15 +15945,17 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -16495,10 +16510,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -16798,11 +16815,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@17.3.17(698f3eb18ebd1873936932a8f28e1e0c)':
+  '@angular-devkit/build-angular@17.3.17(1257b75eff6e506ce5439c979d44240a)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1703.17(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      '@angular-devkit/build-webpack': 0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       '@angular-devkit/core': 17.3.17(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.2.2)
       '@babel/core': 7.26.10
@@ -16815,16 +16832,16 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/runtime': 7.26.10
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.2.2))(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      '@ngtools/webpack': 17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.2.2))(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.19(@types/node@22.15.33)(less@4.2.0)(lightningcss@1.30.1)(sass@1.71.1)(terser@5.29.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.18(postcss@8.4.35)
-      babel-loader: 9.1.3(@babel/core@7.26.10)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      babel-loader: 9.1.3(@babel/core@7.26.10)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       babel-plugin-istanbul: 6.1.1
       browserslist: 4.25.1
-      copy-webpack-plugin: 11.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      copy-webpack-plugin: 11.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       critters: 0.0.22
-      css-loader: 6.10.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      css-loader: 6.10.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       esbuild-wasm: 0.20.1
       fast-glob: 3.3.2
       http-proxy-middleware: 2.0.8(@types/express@4.17.23)
@@ -16833,11 +16850,11 @@ snapshots:
       jsonc-parser: 3.2.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 11.1.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
-      license-webpack-plugin: 4.0.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      less-loader: 11.1.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
+      license-webpack-plugin: 4.0.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       loader-utils: 3.2.1
       magic-string: 0.30.8
-      mini-css-extract-plugin: 2.8.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      mini-css-extract-plugin: 2.8.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       mrmime: 2.0.0
       open: 8.4.2
       ora: 5.4.1
@@ -16845,13 +16862,13 @@ snapshots:
       picomatch: 4.0.1
       piscina: 4.4.0
       postcss: 8.4.35
-      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.71.1
-      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       semver: 7.6.0
-      source-map-loader: 5.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      source-map-loader: 5.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       source-map-support: 0.5.21
       terser: 5.29.1
       tree-kill: 1.2.2
@@ -16860,10 +16877,10 @@ snapshots:
       vite: 5.4.19(@types/node@22.15.33)(less@4.2.0)(lightningcss@1.30.1)(sass@1.71.1)(terser@5.29.1)
       watchpack: 2.4.0
       webpack: 5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)
-      webpack-dev-middleware: 6.1.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
-      webpack-dev-server: 4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      webpack-dev-middleware: 6.1.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
+      webpack-dev-server: 4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
     optionalDependencies:
       '@angular/platform-server': 17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10))(@angular/platform-browser@17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))
       esbuild: 0.20.1
@@ -16889,12 +16906,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))':
+  '@angular-devkit/build-webpack@0.1703.17(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))':
     dependencies:
       '@angular-devkit/architect': 0.1703.17(chokidar@3.6.0)
       rxjs: 7.8.1
       webpack: 5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)
-      webpack-dev-server: 4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      webpack-dev-server: 4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
     transitivePeerDependencies:
       - chokidar
 
@@ -20488,18 +20505,18 @@ snapshots:
 
   '@master/colors@3.0.0': {}
 
-  '@master/css-devtools-hook@2.0.0-rc.68': {}
+  '@master/css-devtools-hook@2.0.0-rc.69': {}
 
-  '@master/css-language@2.0.0-rc.68': {}
+  '@master/css-language@2.0.0-rc.69': {}
 
-  '@master/css-runtime@2.0.0-rc.68':
+  '@master/css-runtime@2.0.0-rc.69':
     dependencies:
-      '@master/css': 2.0.0-rc.68
-      '@master/css-devtools-hook': 2.0.0-rc.68
+      '@master/css': 2.0.0-rc.69
+      '@master/css-devtools-hook': 2.0.0-rc.69
 
-  '@master/css.react@2.0.0-rc.68(@types/react@19.1.8)(react@19.1.0)':
+  '@master/css.react@2.0.0-rc.69(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@master/css-runtime': 2.0.0-rc.68
+      '@master/css-runtime': 2.0.0-rc.69
       '@types/react': 19.1.8
       react: 19.1.0
 
@@ -20510,12 +20527,12 @@ snapshots:
       '@techor/extend': 3.2.5
       csstype: 3.1.3
 
-  '@master/css@2.0.0-rc.68':
+  '@master/css@2.0.0-rc.69':
     dependencies:
-      '@master/colors': 2.2.0
+      '@master/colors': 3.0.0
       '@master/normal.css': 3.2.0
-      '@techor/extend': 3.2.5
       csstype: 3.1.3
+      json-safe-extend: 3.2.5
 
   '@master/normal.css@3.2.0': {}
 
@@ -20623,12 +20640,12 @@ snapshots:
       uuid: 11.1.0
       write-file-atomic: 6.0.0
 
-  '@netlify/functions@3.1.10(rollup@4.44.1)':
+  '@netlify/functions@3.1.10(encoding@0.1.13)(rollup@4.44.1)':
     dependencies:
       '@netlify/blobs': 9.1.2
       '@netlify/dev-utils': 2.2.0
       '@netlify/serverless-functions-api': 1.41.2
-      '@netlify/zip-it-and-ship-it': 12.1.5(rollup@4.44.1)
+      '@netlify/zip-it-and-ship-it': 12.1.5(encoding@0.1.13)(rollup@4.44.1)
       cron-parser: 4.9.0
       decache: 4.6.2
       extract-zip: 2.0.1
@@ -20650,7 +20667,7 @@ snapshots:
 
   '@netlify/serverless-functions-api@2.1.2': {}
 
-  '@netlify/zip-it-and-ship-it@12.1.5(rollup@4.44.1)':
+  '@netlify/zip-it-and-ship-it@12.1.5(encoding@0.1.13)(rollup@4.44.1)':
     dependencies:
       '@babel/parser': 7.27.7
       '@babel/types': 7.27.6
@@ -20734,7 +20751,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.3.4':
     optional: true
 
-  '@ngtools/webpack@17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.2.2))(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))':
+  '@ngtools/webpack@17.3.17(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.2.2))(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))':
     dependencies:
       '@angular/compiler-cli': 17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.2.2)
       typescript: 5.2.2
@@ -23257,10 +23274,10 @@ snapshots:
       '@types/node': 22.15.33
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.35.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.35.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.35.0
       '@typescript-eslint/type-utils': 8.35.0(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/utils': 8.35.0(eslint@8.57.1)(typescript@5.8.3)
@@ -24637,7 +24654,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.26.10)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  babel-loader@9.1.3(@babel/core@7.26.10)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
@@ -25473,7 +25490,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  copy-webpack-plugin@11.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  copy-webpack-plugin@11.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -25625,7 +25642,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@6.10.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  css-loader@6.10.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.35)
       postcss: 8.4.35
@@ -26483,12 +26500,12 @@ snapshots:
     dependencies:
       '@next/eslint-plugin-next': 15.3.4
       '@rushstack/eslint-patch': 1.12.0
-      '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser': 8.35.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -26556,7 +26573,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@5.5.0)
@@ -26567,7 +26584,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.9.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-import-x: 4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
@@ -26583,7 +26600,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.9.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-import-x: 4.16.0(@typescript-eslint/utils@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.29.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
@@ -26612,14 +26629,14 @@ snapshots:
     dependencies:
       eslint: 9.29.0(jiti@2.4.2)
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.35.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.0(@typescript-eslint/utils@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26671,7 +26688,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -26682,7 +26699,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -26694,7 +26711,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.35.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -26728,6 +26745,36 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.29.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    optional: true
 
   eslint-plugin-jsdoc@50.8.0(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
@@ -28399,7 +28446,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  html-webpack-plugin@5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -29885,7 +29932,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@11.1.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  less-loader@11.1.0(less@4.2.0)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       klona: 2.0.6
       less: 4.2.0
@@ -29918,7 +29965,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  license-webpack-plugin@4.0.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -30835,7 +30882,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.8.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  mini-css-extract-plugin@2.8.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.2
@@ -31120,10 +31167,10 @@ snapshots:
       node-gyp-build: 4.8.4
     optional: true
 
-  nitropack@2.11.13(@azure/identity@4.10.1):
+  nitropack@2.11.13(@azure/identity@4.10.1)(encoding@0.1.13):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
-      '@netlify/functions': 3.1.10(rollup@4.44.1)
+      '@netlify/functions': 3.1.10(encoding@0.1.13)(rollup@4.44.1)
       '@rollup/plugin-alias': 5.1.1(rollup@4.44.1)
       '@rollup/plugin-commonjs': 28.0.6(rollup@4.44.1)
       '@rollup/plugin-inject': 5.0.5(rollup@4.44.1)
@@ -31413,7 +31460,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.17.5(@azure/identity@4.10.1)(@parcel/watcher@2.5.1)(@types/node@22.15.33)(db0@0.3.2)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0):
+  nuxt@3.17.5(@azure/identity@4.10.1)(@parcel/watcher@2.5.1)(@types/node@22.15.33)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.33)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0):
     dependencies:
       '@nuxt/cli': 3.25.1(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
@@ -31448,7 +31495,7 @@ snapshots:
       mlly: 1.7.4
       mocked-exports: 0.1.1
       nanotar: 0.2.0
-      nitropack: 2.11.13(@azure/identity@4.10.1)
+      nitropack: 2.11.13(@azure/identity@4.10.1)(encoding@0.1.13)
       nypm: 0.6.0
       ofetch: 1.4.1
       ohash: 2.0.11
@@ -32140,7 +32187,7 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.12.7(@swc/helpers@0.5.17))(@types/node@22.15.33)(typescript@5.8.3)
 
-  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.2.2)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.2.2)
       jiti: 1.21.7
@@ -33260,7 +33307,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@14.1.1(sass@1.71.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  sass-loader@14.1.1(sass@1.71.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -33724,7 +33771,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  source-map-loader@5.0.0(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -34284,7 +34331,7 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -35699,7 +35746,7 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.99.9)
 
-  webpack-dev-middleware@5.3.4(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  webpack-dev-middleware@5.3.4(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -35717,7 +35764,7 @@ snapshots:
       schema-utils: 4.3.2
       webpack: 5.99.9(@swc/core@1.12.7(@swc/helpers@0.5.17))(webpack-cli@5.1.4)
 
-  webpack-dev-middleware@6.1.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  webpack-dev-middleware@6.1.2(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -35727,7 +35774,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)
 
-  webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  webpack-dev-server@4.15.1(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -35757,7 +35804,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      webpack-dev-middleware: 5.3.4(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       ws: 8.18.2
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)
@@ -35820,12 +35867,12 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))))(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)
     optionalDependencies:
-      html-webpack-plugin: 5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      html-webpack-plugin: 5.6.3(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
 
   webpack-virtual-modules@0.5.0: {}
 
@@ -35853,7 +35900,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.12.7(@swc/helpers@0.5.17))(esbuild@0.20.1)(webpack@5.94.0(@swc/core@1.12.7(@swc/helpers@0.5.17)))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Problem (re-classified)

Three races, on **two different code paths** — please read the table before the sections below, they are not all "static generation":

| Tag | File | When it runs | Pipeline |
|---|---|---|---|
| **C1** | `packages/webpack/src/index.ts` | every webpack build / `--watch` rebuild | **build (static generation)** |
| **C2** | `packages/vite/src/plugins/virtual-css-hmr.ts` (`apply: 'serve'`) | `vite dev` only | **dev-server HMR** |
| **C3** | same file, same `apply: 'serve'` | `vite dev` only | **dev-server HMR** |

`virtual-css-hmr.ts:73` is `apply: 'serve'`, so C2/C3 do not run during `vite build`. The Vite **build** path goes through `extract.ts` + `virtual-css-module.ts` (`apply: 'build'`) and is unchanged by this PR.

The earlier framing of "static generation races" was inaccurate — C2/C3 are HMR-only.

### C1 — webpack build: `succeedModule.tap()` runs `async` callback that webpack discards

`compilation.hooks.succeedModule` is a tapable **`SyncHook`** (verified at `webpack@5.94.0/lib/Compilation.js:632` — `succeedModule: new SyncHook(["module"])`). Attaching an `async` callback via `.tap()` returns a Promise tapable does not await. Webpack proceeds to `emit` while `extractor.insert()` is still pending → output CSS can be missing classes from late-arriving modules. This **does** affect every production build.

### C2 — vite dev HMR: `tasks.concat(...)` result discarded

`virtual-css-hmr.ts:48` (pre-fix). `Array.prototype.concat` returns a new array; does not mutate. The third arm of `handleReset` — re-extracting every open module after a config-file save — was scheduled but its promises were never awaited by `Promise.all(tasks)`. After config-file save, HMR could publish CSS before reset finished re-extracting open modules.

### C3 — vite dev HMR: `reset` and `change` listeners fire-and-forget

Same file, `buildStart()`. `extractor.on('reset', () => servers.forEach(s => handleReset({server:s})))` does not await — `EventEmitter` does not await async listeners. Two saves in quick succession overlap; the second `prepare()` runs while the first is still mutating `extractor.css`.

## Motivation

These are the highest-confidence subset of a 12-finding audit of the static-gen + integration packages. Bundled because:
- All three are real races (not "might be slow"), each fix is two-to-five lines.
- None touch the public surface (`PluginOptions`, event names, mode strings, virtual-module IDs — all unchanged).
- All three were unguarded by tests (webpack package had **0** tests; vite had no HMR tests).

The remaining 9 audit findings (slot-CSS-rule placeholder fragility, extract-mode silently overwriting user `include`, pre-render config staleness, etc.) are intentionally out of scope.

## Result

### C1 — webpack
- `succeedModule.tap()` now only **synchronously** records source into a per-compilation `pendingByPath` map.
- A new `compilation.hooks.finishModules.tapPromise()` (`AsyncSeriesHook`, verified at `Compilation.js:656`) awaits all pending inserts in parallel before resolving. Webpack blocks on AsyncSeriesHook promises before processing assets.
- Map is closure-scoped per compilation, so watch-mode rebuilds do not re-insert previously-seen modules.

### C2 — vite `handleReset`
- `tasks.concat(...)` → `tasks.push(...arr)` so the module-graph promises are actually held.
- Removed inline `await prepare()` (defeated the parallel `Promise.all`).
- Awaited the trailing `updateVirtualModule` so the chain settles before the next event.

### C3 — vite event listeners
- Both `reset` and `change` now feed onto independent Promise queues; a second event is queued behind the first rather than overlapping it.
- Errors caught and logged (`console.error('[master-css.vite] reset/hmr update failed:', err)`) instead of becoming unhandled rejections.
- `updateVirtualModule` now `await`s `server.reloadModule()` — without this the chain resolves before the heavy reload work, defeating the serialisation.

### What did NOT change
- `PluginOptions` (vite + webpack) — identical.
- Event names emitted by `CSSExtractor` — identical.
- Virtual module IDs, mode strings, default config — identical.
- Vite **build** path (`extract.ts` + `virtual-css-module.ts`) — untouched.

## Evidence

### Unit tests (new)

**`packages/webpack/tests/plugin.test.ts`** — 4 cases (vitest); package had **0 tests** before this PR:
1. `finishModules.tapPromise` awaits all `extractor.insert()` calls before resolving — the inverse of the C1 race.
2. **Pins down the original bug**: a real `SyncHook + tap(async)` does NOT await. If tapable ever changes this (it never has), the regression catches it.
3. Per-compilation `pendingByPath` is isolated across watch rebuilds.
4. Modules without resource paths (virtual / runtime helpers) are skipped without throwing.

**`packages/vite/tests/plugins/virtual-css-hmr.test.ts`** — 5 cases (vitest); no HMR test existed before:
1. `handleReset` awaits `prepare()`, index.html re-insert, AND every module-graph promise (C2 regression).
2. A second `reset` is queued behind the first — no overlap (C3 regression for reset).
3. A second `change` is queued behind the first — no overlap (C3 regression for change; pinned via `server.reloadModule` spy).
4. An error in one reset does not poison the chain — subsequent resets still run.
5. `handleReset` completes only after the **slowest** module-graph insert, regardless of ordering — would catch a re-introduction of C2.

### End-to-end smoke

**Webpack build path (the C1 fix is in this code path):**
- `pnpm --filter master-css-webpack-example build`
- Plugin reports `✓ src/index.html 19 classes inserted in 86.9ms`
- `dist/bundle.js` contains every expected real CSS rule — `justify-content:center`, `background-image:linear-gradient(120deg,#1b78bf 30%,#8ed6fb)`, `font-weight:900`, `letter-spacing:-0.015625em`, `gap:1.875rem`, `position:absolute`, `width:100%`, `margin:0rem`, `width:6.875rem` (size:110), `width:10.75rem` (size:172), …
- agent-browser opened `dist/index.html`: gradient "Webpack + Master CSS" title and Webpack/Master logos render correctly.

**Vite build path (NOT touched by this PR — smoke proves the HMR changes did not regress the build path):**
- `pnpm --filter master-css-vite-example build`
- Output: `dist/assets/index-DwRtqU8J.css` 3.96 kB / gzip 1.75 kB
- Contains real Master CSS output: `background-image:linear-gradient(120deg,#bd34fe 30%,#41d1ff)`, `background-clip:text`, `align-items:center`, `font-weight:500/900`, `border-radius:8px`, …
- **Slot CSS placeholder leakage check**: `grep -c "slot:0\|virtual\\:master" dist/assets/*.css` → **0**. The `virtual-css-module.ts` placeholder→real-CSS replacement still works post-PR. (Audit finding D1 about that mechanism's general fragility is unchanged — that's a separate PR.)

**Vite dev HMR path (the C2/C3 fixes are in this code path):**
- Started `examples/vite` (mode: 'extract') dev server, agent-browser screenshotted: "Vite + Master CSS" page renders correctly with gradient title, logos, button.
- Edited `src/main.ts` to add `document.body.classList.add('bg:fuchsia-50', 'fg:emerald-50')`.
- Re-fetched `/@id/\0virtual:master.css` — `fuchsia` rule now present in payload. Confirms HMR pipeline (`transform` → `insert` → `change` event → serialised `updateVirtualModule` → ws update) is intact post-fix.

### Aggregate test status

| Package | Before | After |
|---|---:|---:|
| `@master/css-extractor` | 25 / 25 | 25 / 25 |
| `@master/css.vite` | 11 / 11 | **16** / 16 |
| `@master/css.webpack` | **0 / 0** | **4 / 4** |
| `@master/css.nuxt` | 4 / 4 | 4 / 4 |
| **Total** | 40 | **49 / 49 pass** |

Lint + type-check clean for changed packages (`@master/css.vite`, `@master/css.webpack`).

## Test plan

- [x] `pnpm --filter @master/css.vite --filter @master/css.webpack test --run` — 20/20 pass
- [x] `pnpm --filter @master/css.vite --filter @master/css.webpack lint` — clean
- [x] `pnpm --filter @master/css.vite --filter @master/css.webpack type-check` — clean
- [x] `examples/webpack` build → CSS classes in bundle, browser renders correctly (covers C1)
- [x] `examples/vite` build → 3.96 kB CSS with real rules, no slot placeholder leakage (proves no regression in untouched build path)
- [x] `examples/vite` (extract mode) dev server → HMR add-class round-trip works (covers C2/C3)
