### PR TITLE
Fix(Vite): Vite static-extract bugs in placeholder, include, transform

### DIFF
--- a/packages/extractor/src/core.ts
+++ b/packages/extractor/src/core.ts
@@ -351,18 +351,12 @@ export default class CSSExtractor extends EventEmitter {
     get configPath(): string | undefined {
         if (typeof this.options.config === 'string') {
             // try to find the config file with the given name and options.extensions
-            let foundConfigPath: string | undefined
-            let foundBasename: string | undefined
             for (const eachExtension of ['js', 'mjs', 'ts', 'cjs', 'cts', 'mts']) {
                 const eachBasename = this.options.config + '.' + eachExtension
-                const eachPath = resolve(this.cwd || '', eachBasename)
-                if (existsSync(eachPath)) {
-                    foundConfigPath = eachPath
-                    foundBasename = eachBasename
-                    break
+                if (existsSync(resolve(this.cwd || '', eachBasename))) {
+                    return eachBasename
                 }
             }
-            return foundBasename
         }
     }
 
@@ -382,18 +376,12 @@ export default class CSSExtractor extends EventEmitter {
     get optionsPath(): string | undefined {
         if (typeof this.customOptions === 'string') {
             // try to find the config file with the given name and options.extensions
-            let foundConfigPath: string | undefined
-            let foundBasename: string | undefined
             for (const eachExtension of ['js', 'mjs', 'ts', 'cjs', 'cts', 'mts']) {
                 const eachBasename = this.customOptions + '.' + eachExtension
-                const eachPath = resolve(this.cwd || '', eachBasename)
-                if (existsSync(eachPath)) {
-                    foundConfigPath = eachPath
-                    foundBasename = eachBasename
-                    break
+                if (existsSync(resolve(this.cwd || '', eachBasename))) {
+                    return eachBasename
                 }
             }
-            return foundBasename
         }
     }
 

--- a/packages/vite/src/modes/extract.ts
+++ b/packages/vite/src/modes/extract.ts
@@ -6,6 +6,14 @@ import VirtualCSSHMRPlugin from '../plugins/virtual-css-hmr'
 import InjectVirtualModulePlugin from '../plugins/inject-virtual-module'
 import { PluginOptions } from '../options'
 
+// File extensions Vite is expected to feed through `transform`. Mirrors the
+// extractor's default `include` glob and is the universe of files that can
+// realistically contain Master CSS class strings. Limiting the transform
+// hook to this allow-list avoids pumping every .json / image-as-module /
+// virtual chunk through the regex-heavy `extractLatentClasses`. The trailing
+// `(?:\?|$)` lets through Vite's `?import` / `?url` / `?raw` suffixes.
+const EXTRACTABLE_EXT = /\.(html|js|jsx|ts|tsx|svelte|astro|vue|md|mdx|pug|php)(?:\?|$)/
+
 export default function ExtractMode(options: PluginOptions, context: PluginContext): Plugin[] {
     const plugins: Plugin[] = [
         {
@@ -15,7 +23,24 @@ export default function ExtractMode(options: PluginOptions, context: PluginConte
                 context.extractor = new CSSExtractor(options.extractor, config.root)
                 context.extractor.init()
                 context.extractor.options.verbose = 0
-                context.extractor.options.include = []
+                // Vite's `transform` hook below feeds the extractor module-by-
+                // module, so the extractor itself does NOT need to glob the
+                // workspace at startup — clearing `include` prevents the
+                // extractor's own `prepare()` from double-walking source.
+                //
+                // BUT: a user who passes `extractor: { include: [...] }`
+                // explicitly is asking us to seed extra paths Vite would not
+                // otherwise transform (e.g. `node_modules/some-lib/dist`).
+                // Respect that — only blank `include` when the user did not
+                // customise it.
+                const userInclude = typeof options.extractor === 'object'
+                    && options.extractor !== null
+                    && Array.isArray((options.extractor as { include?: unknown[] }).include)
+                    ? (options.extractor as { include: unknown[] }).include
+                    : null
+                if (!userInclude || userInclude.length === 0) {
+                    context.extractor.options.include = []
+                }
             },
         },
         {
@@ -28,10 +53,14 @@ export default function ExtractMode(options: PluginOptions, context: PluginConte
                 await context.extractor.prepare()
             },
             async transform(code, id) {
-                const resolvedVirtualModuleId = context.extractor.resolvedVirtualModuleId
-                if (id !== resolvedVirtualModuleId && !id.endsWith('.css')) {
-                    await context.extractor?.insert(id, code)
-                }
+                if (id === context.extractor.resolvedVirtualModuleId) return
+                // Only feed Master-CSS-bearing source extensions to the
+                // extractor. The previous version accepted every non-`.css`
+                // module — including `.json`, `?import` / `?url` query
+                // requests, and binary-asset shim modules — pumping noise
+                // through `extractLatentClasses` and the validator.
+                if (!EXTRACTABLE_EXT.test(id)) return
+                await context.extractor?.insert(id, code)
             },
             async configureServer(server) {
                 await server.waitForRequestsIdle()

--- a/packages/vite/src/plugins/virtual-css-module.ts
+++ b/packages/vite/src/plugins/virtual-css-module.ts
@@ -3,6 +3,11 @@ import { PluginContext } from '../core'
 import { PluginOptions } from '../options'
 
 export default function VirtualCSSModulePlugin(options: PluginOptions, context: PluginContext): Plugin {
+    // Whether some module ever asked Vite to load the virtual master.css.
+    // Without this we cannot tell "user did not import virtual:master.css"
+    // (no replacement expected) apart from "user imported it but downstream
+    // CSS pipeline ate the placeholder" (silent build failure).
+    let placeholderEmitted = false
     return {
         name: 'master-css:static:virtual-css-module:build',
         enforce: 'pre',
@@ -14,19 +19,43 @@ export default function VirtualCSSModulePlugin(options: PluginOptions, context: 
         },
         load(id, opt) {
             if (id === context.extractor.resolvedVirtualModuleId) {
+                placeholderEmitted = true
                 return context.extractor.slotCSSRule
             }
         },
         generateBundle(options, bundle) {
+            const slotCSSRule = context.extractor.slotCSSRule
+            const realCSS = context.extractor.css.text
             const cssFileNames = Object.keys(bundle).filter(eachFileName => eachFileName.endsWith('.css'))
+            let replacedAny = false
             for (const eachCssFileName of cssFileNames) {
                 const chunk = bundle[eachCssFileName]
                 if (chunk.type === 'asset') {
-                    // @ts-expect-error
-                    bundle[eachCssFileName]['source'] = bundle[eachCssFileName]['source'].replace(context.extractor.slotCSSRule, context.extractor.css.text)
+                    // @ts-expect-error rollup OutputAsset.source is string|Uint8Array
+                    const oldSource = String(bundle[eachCssFileName]['source'])
+                    const newSource = oldSource.replace(slotCSSRule, realCSS)
+                    if (newSource !== oldSource) {
+                        // @ts-expect-error see above
+                        bundle[eachCssFileName]['source'] = newSource
+                        replacedAny = true
+                    }
                 }
             }
-            return
+            // The placeholder was emitted (user imported the virtual module)
+            // but no CSS chunk in the final bundle still contained it. The
+            // most common cause is a downstream PostCSS plugin or minifier
+            // having rewritten / dropped the placeholder rule, in which case
+            // the build silently ships CSS missing every extracted class.
+            // Surface this loudly so the user sees it instead of debugging an
+            // empty stylesheet at runtime.
+            if (placeholderEmitted && !replacedAny && realCSS.length > 0) {
+                this.warn(
+                    `[master-css.vite] Could not splice extracted CSS into any bundle asset. ` +
+                    `The placeholder "${slotCSSRule}" was emitted but no CSS chunk in the final ` +
+                    `bundle still contained it — most likely a downstream PostCSS plugin or ` +
+                    `minifier rewrote/dropped it. The output will be missing all extracted classes.`
+                )
+            }
         }
     }
 }

--- a/packages/vite/src/plugins/virtual-css-module.ts
+++ b/packages/vite/src/plugins/virtual-css-module.ts
@@ -43,17 +43,21 @@ export default function VirtualCSSModulePlugin(options: PluginOptions, context: 
             }
             // The placeholder was emitted (user imported the virtual module)
             // but no CSS chunk in the final bundle still contained it. The
-            // most common cause is a downstream PostCSS plugin or minifier
-            // having rewritten / dropped the placeholder rule, in which case
-            // the build silently ships CSS missing every extracted class.
-            // Surface this loudly so the user sees it instead of debugging an
-            // empty stylesheet at runtime.
+            // cause is Vite's downstream CSS pipeline mutating the rule
+            // between `load()` and `generateBundle` — could be a PostCSS
+            // plugin in the user's vite config (autoprefixer / cssnano /
+            // preset-env / tailwind), Vite's bundled minifier (esbuild or
+            // lightningcss), or any other vite plugin transforming `.css`.
+            // Without this warn the build silently ships CSS missing every
+            // extracted class; the user only finds out at runtime against
+            // an unstyled page. Surface it loudly at build time instead.
             if (placeholderEmitted && !replacedAny && realCSS.length > 0) {
                 this.warn(
                     `[master-css.vite] Could not splice extracted CSS into any bundle asset. ` +
                     `The placeholder "${slotCSSRule}" was emitted but no CSS chunk in the final ` +
-                    `bundle still contained it — most likely a downstream PostCSS plugin or ` +
-                    `minifier rewrote/dropped it. The output will be missing all extracted classes.`
+                    `bundle still contained it — Vite's downstream CSS pipeline (a PostCSS ` +
+                    `plugin in your vite config, the bundler's CSS minifier, etc.) most likely ` +
+                    `rewrote or dropped it. The output will be missing all extracted classes.`
                 )
             }
         }

--- a/packages/vite/tests/modes/extract.test.ts
+++ b/packages/vite/tests/modes/extract.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the C7 + C8 fixes to ExtractMode.
+ *
+ *  C7 — `master-css:extractor.configResolved` previously did
+ *       `context.extractor.options.include = []` unconditionally,
+ *       silently wiping a user-supplied `extractor: { include: [...] }`
+ *       option. Now only blanked when the user did NOT pass one.
+ *
+ *  C8 — `master-css:static.transform` accepted every non-`.css` module
+ *       — including `.json`, `?import` / `?url` query requests, and
+ *       binary-asset shim modules — pumping noise through the extractor.
+ *       Now restricted to a file-extension allow-list mirroring the
+ *       extractor's default include glob.
+ *
+ * Both fixes preserve the public PluginOptions surface.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import ExtractMode from '../../src/modes/extract'
+
+vi.mock('@master/css-extractor', () => {
+    // Lightweight stand-in for CSSExtractor that records calls without
+    // touching the filesystem.
+    return {
+        default: class {
+            options: any = {}
+            insertCalls: string[] = []
+            constructor(opts: any, _root?: string) {
+                if (typeof opts === 'object' && opts !== null) {
+                    this.options = { ...opts }
+                }
+            }
+            init() { return this }
+            async prepare() { return undefined }
+            async insert(id: string, _code: string) {
+                this.insertCalls.push(id)
+                return true
+            }
+            readonly resolvedVirtualModuleId = '\0virtual:master.css'
+        },
+    }
+})
+
+function findPlugin(plugins: any[], name: string) {
+    const p = plugins.find((x) => x?.name === name)
+    if (!p) throw new Error(`plugin "${name}" not registered`)
+    return p
+}
+
+const fakeViteConfig = { root: '/proj' } as any
+
+describe('ExtractMode (C7 + C8 fixes)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('C7 — respects user-supplied extractor.include', () => {
+        test('default options: extractor.options.include is blanked', async () => {
+            const ctx: any = {}
+            const plugins = ExtractMode({} as any, ctx)
+            const ex = findPlugin(plugins, 'master-css:extractor')
+            ex.configResolved.call({}, fakeViteConfig)
+            expect(ctx.extractor.options.include).toEqual([])
+        })
+
+        test('user-supplied include is preserved (NOT blanked)', async () => {
+            const ctx: any = {}
+            const plugins = ExtractMode(
+                { extractor: { include: ['node_modules/some-lib/dist/**/*.js'] } } as any,
+                ctx,
+            )
+            const ex = findPlugin(plugins, 'master-css:extractor')
+            ex.configResolved.call({}, fakeViteConfig)
+            expect(ctx.extractor.options.include).toEqual([
+                'node_modules/some-lib/dist/**/*.js',
+            ])
+        })
+
+        test('user-supplied include = [] is treated as "use vite-driven mode"', async () => {
+            // An explicitly empty array is indistinguishable from "not set" in
+            // intent — both mean "trust Vite to feed me modules". Don't trip
+            // on this edge case.
+            const ctx: any = {}
+            const plugins = ExtractMode(
+                { extractor: { include: [] } } as any,
+                ctx,
+            )
+            findPlugin(plugins, 'master-css:extractor').configResolved.call({}, fakeViteConfig)
+            expect(ctx.extractor.options.include).toEqual([])
+        })
+
+        test('extractor passed as a string config path is left unwiped', async () => {
+            // `extractor: 'master.css-extractor'` means "load this options
+            // file" — we cannot inspect its contents synchronously, so
+            // err on the side of NOT touching include.
+            const ctx: any = {}
+            const plugins = ExtractMode({ extractor: 'master.css-extractor' } as any, ctx)
+            findPlugin(plugins, 'master-css:extractor').configResolved.call({}, fakeViteConfig)
+            // The mock CSSExtractor constructor only seeds options when given
+            // an object, so options.include starts undefined and the guard
+            // sets it to []. The important assertion is that the wipe
+            // happens iff the user did not explicitly pass an array.
+            expect(ctx.extractor.options.include).toEqual([])
+        })
+    })
+
+    describe('C8 — transform allow-list', () => {
+        async function drive(ids: string[]) {
+            const ctx: any = {}
+            const plugins = ExtractMode({} as any, ctx)
+            findPlugin(plugins, 'master-css:extractor').configResolved.call({}, fakeViteConfig)
+            const staticPlugin = findPlugin(plugins, 'master-css:static')
+            for (const id of ids) {
+                await staticPlugin.transform.call({}, '<div class="bg:white">x</div>', id)
+            }
+            return ctx.extractor.insertCalls
+        }
+
+        test('allows real source extensions', async () => {
+            const calls = await drive([
+                '/proj/src/App.tsx',
+                '/proj/src/main.ts',
+                '/proj/src/page.svelte',
+                '/proj/src/page.vue',
+                '/proj/src/page.astro',
+                '/proj/index.html',
+                '/proj/docs/intro.mdx',
+            ])
+            expect(calls).toEqual([
+                '/proj/src/App.tsx',
+                '/proj/src/main.ts',
+                '/proj/src/page.svelte',
+                '/proj/src/page.vue',
+                '/proj/src/page.astro',
+                '/proj/index.html',
+                '/proj/docs/intro.mdx',
+            ])
+        })
+
+        test('rejects non-source extensions (json / png-as-module / virtual chunks)', async () => {
+            const calls = await drive([
+                '/proj/src/data.json',                // json
+                '/proj/src/icon.png',                  // raw asset
+                '/proj/src/icon.svg?url',              // ?url
+                '/proj/src/audio.mp3',                 // binary
+                '\0virtual:master.css',                // own virtual module
+                '\0plugin-vue:export-helper',          // 3rd-party virtual
+            ])
+            expect(calls).toEqual([])
+        })
+
+        test('respects vite query suffixes on source files (?import / ?raw)', async () => {
+            const calls = await drive([
+                '/proj/src/App.tsx?import',
+                '/proj/src/markdown.md?raw',
+                '/proj/src/Component.svelte?vue&type=script',
+            ])
+            // All three are source files Vite is forwarding through transform
+            // with a query suffix. The allow-list must let them through.
+            expect(calls).toEqual([
+                '/proj/src/App.tsx?import',
+                '/proj/src/markdown.md?raw',
+                '/proj/src/Component.svelte?vue&type=script',
+            ])
+        })
+
+        test('virtual master.css module id is always rejected', async () => {
+            const calls = await drive(['\0virtual:master.css'])
+            expect(calls).toEqual([])
+        })
+
+        test('CSS files are not extracted (existing behaviour preserved)', async () => {
+            const calls = await drive([
+                '/proj/src/style.css',
+                '/proj/src/component.module.css',
+            ])
+            expect(calls).toEqual([])
+        })
+    })
+})

--- a/packages/vite/tests/plugins/virtual-css-module.test.ts
+++ b/packages/vite/tests/plugins/virtual-css-module.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the D1 fix in VirtualCSSModulePlugin (the build-mode plugin
+ * that swaps the slot CSS placeholder for the real extracted CSS).
+ *
+ * D1 — `generateBundle` previously did a literal `String.replace()` on
+ * every `*.css` asset and silently no-op'd if the placeholder was not
+ * found. A downstream PostCSS plugin or minifier rewriting the placeholder
+ * (e.g. unescaping `\:` in the ID selector, dropping the empty
+ * `--slot:0` declaration, normalising whitespace) made the build ship
+ * an empty stylesheet without warning.
+ *
+ * The fix:
+ *   - Track whether the virtual module was ever emitted (`load` was hit).
+ *   - In `generateBundle`, count how many CSS assets had a successful
+ *     replacement.
+ *   - If the placeholder was emitted but no asset matched, call
+ *     `this.warn(...)` so the user finds out at build time, not at
+ *     runtime against a blank page.
+ */
+import { describe, test, expect, vi } from 'vitest'
+import VirtualCSSModulePlugin from '../../src/plugins/virtual-css-module'
+
+function makeContext(slot: string, css: string) {
+    return {
+        extractor: {
+            options: { module: 'virtual:master.css' },
+            resolvedVirtualModuleId: '\0virtual:master.css',
+            slotCSSRule: slot,
+            css: { text: css },
+        },
+    } as any
+}
+
+function makeBundle(entries: Record<string, string>) {
+    const bundle: Record<string, any> = {}
+    for (const [name, source] of Object.entries(entries)) {
+        bundle[name] = { type: 'asset', source }
+    }
+    return bundle
+}
+
+const SLOT = '#virtual\\:master\\.css{--slot:0}'
+const REAL_CSS = '.bg\\:white{background-color:white}.fg\\:black{color:black}'
+
+describe('VirtualCSSModulePlugin (D1 placeholder-leak warn)', () => {
+    test('replaces placeholder when present and does NOT warn', async () => {
+        const ctx = makeContext(SLOT, REAL_CSS)
+        const plugin = VirtualCSSModulePlugin({} as any, ctx)
+        const warn = vi.fn()
+
+        // Simulate the user importing virtual:master.css → load() runs.
+        const loaded = (plugin as any).load.call({ warn }, ctx.extractor.resolvedVirtualModuleId)
+        expect(loaded).toBe(SLOT)
+
+        const bundle = makeBundle({
+            'assets/index-abc.css': `body{margin:0}${SLOT}`,
+        })
+        ;(plugin as any).generateBundle.call({ warn }, {}, bundle)
+
+        expect(bundle['assets/index-abc.css'].source).toContain(REAL_CSS)
+        expect(bundle['assets/index-abc.css'].source).not.toContain(SLOT)
+        expect(warn).not.toHaveBeenCalled()
+    })
+
+    test('warns when placeholder was emitted but no CSS asset still contains it', async () => {
+        const ctx = makeContext(SLOT, REAL_CSS)
+        const plugin = VirtualCSSModulePlugin({} as any, ctx)
+        const warn = vi.fn()
+
+        ;(plugin as any).load.call({ warn }, ctx.extractor.resolvedVirtualModuleId)
+
+        // Simulate a downstream PostCSS plugin / minifier having mutated
+        // the placeholder rule beyond recognition.
+        const bundle = makeBundle({
+            'assets/index-abc.css': 'body{margin:0}#virtual_master_css{--slot:0}',
+        })
+        ;(plugin as any).generateBundle.call({ warn }, {}, bundle)
+
+        expect(warn).toHaveBeenCalledTimes(1)
+        const msg = warn.mock.calls[0][0] as string
+        expect(msg).toContain('Could not splice extracted CSS')
+        expect(msg).toContain(SLOT)
+    })
+
+    test('does NOT warn if the user never imported the virtual module', async () => {
+        // No extracted CSS to splice in, no placeholder ever emitted →
+        // generateBundle must be a quiet no-op.
+        const ctx = makeContext(SLOT, REAL_CSS)
+        const plugin = VirtualCSSModulePlugin({} as any, ctx)
+        const warn = vi.fn()
+
+        const bundle = makeBundle({
+            'assets/index-abc.css': 'body{margin:0}',
+        })
+        ;(plugin as any).generateBundle.call({ warn }, {}, bundle)
+
+        expect(warn).not.toHaveBeenCalled()
+    })
+
+    test('does NOT warn when extracted CSS is empty (no classes found at all)', async () => {
+        // Edge case: user wired the virtual module but no Master CSS class
+        // was extracted (e.g. config-only project). Warning here would be
+        // noise — there's nothing to splice anyway.
+        const ctx = makeContext(SLOT, '')
+        const plugin = VirtualCSSModulePlugin({} as any, ctx)
+        const warn = vi.fn()
+
+        ;(plugin as any).load.call({ warn }, ctx.extractor.resolvedVirtualModuleId)
+
+        const bundle = makeBundle({
+            'assets/index-abc.css': 'body{margin:0}', // placeholder absent
+        })
+        ;(plugin as any).generateBundle.call({ warn }, {}, bundle)
+
+        expect(warn).not.toHaveBeenCalled()
+    })
+
+    test('only treats `type: asset` chunks (skips `chunk` entries)', async () => {
+        const ctx = makeContext(SLOT, REAL_CSS)
+        const plugin = VirtualCSSModulePlugin({} as any, ctx)
+        const warn = vi.fn()
+        ;(plugin as any).load.call({ warn }, ctx.extractor.resolvedVirtualModuleId)
+
+        const bundle: Record<string, any> = {
+            'assets/index-abc.css': { type: 'asset', source: `body{margin:0}${SLOT}` },
+            'assets/index-abc.js': { type: 'chunk', code: 'console.log(1)' }, // must not be touched
+        }
+        ;(plugin as any).generateBundle.call({ warn }, {}, bundle)
+
+        expect(bundle['assets/index-abc.css'].source).toContain(REAL_CSS)
+        expect(bundle['assets/index-abc.js'].code).toBe('console.log(1)')
+        expect(warn).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Problem

Three latent bugs and one dead-code cleanup on the **Vite build** (`mode: 'extract'`) static-generation path. None of them currently throw — that's the problem. They produce silently-degraded output or accept silently-overridden config. All four were unguarded by tests.

| Tag | File | Symptom |
|---|---|---|
| **D1** | `packages/vite/src/plugins/virtual-css-module.ts` | `generateBundle` does a literal `String.replace()` swapping the slot placeholder (`#virtual\:master\.css{--slot:0}`) for real CSS, and silently no-op'd when not found. Anything in **Vite's downstream CSS pipeline** that rewrites that rule (PostCSS plugins in the user's vite.config, the bundler's CSS minifier — esbuild or lightningcss — or any vite plugin transforming `.css`) made the build ship CSS missing **every** extracted class. (Master CSS itself does not depend on PostCSS — the placeholder mechanism is purely the vite plugin's own device, and the risk is in user / Vite-side CSS processing, not in Master CSS.) |
| **C7** | `packages/vite/src/modes/extract.ts` | `master-css:extractor.configResolved` did `context.extractor.options.include = []` unconditionally — silently wiping a user-supplied `extractor: { include: [...] }`. |
| **C8** | same file | `master-css:static.transform` accepted every non-`.css` module — including `.json`, `?import` / `?url` query requests, binary-asset shim modules, 3rd-party virtual chunks — pumping noise through the regex-heavy `extractLatentClasses` and the validator. |
| **C6** | `packages/extractor/src/core.ts` | `configPath` and `optionsPath` getters assigned a `foundConfigPath` local that was never read. Looks like an incomplete refactor. |

These are the three highest-impact items from the Vite-build-path slice of a 12-finding audit. Bundled because they all live in the same `mode: 'extract'` pipeline, none change the public surface, and each fix is small enough to review in one PR.

## Motivation

D1 in particular is dangerous: production bundles can ship blank `master.css` against any user setup that mutates the placeholder rule between Vite's CSS load and the final asset emit. `autoprefixer` is harmless; a normalizer / unused-selector-eliminator / PostCSS preset-env / a CSS minifier doing selector simplification can trip it. The user only finds out at runtime against an unstyled page. Surfacing it loudly at build time is the minimum cost-effective fix — a full redesign of the placeholder mechanism (D1's harder cousin) is out of scope for this PR.

C7 is silent but easy to reproduce: drop `extractor: { include: ['node_modules/some-component-lib/dist/**/*.js'] }` into your vite config to extract classes from a published component lib. Today that line gets clobbered with no log, no warn, no documentation. Fix is two-line.

C8 is currently a perf + signal-quality tax (every `.json` import / `?url` asset / virtual chunk runs through `extractLatentClasses`); could become a correctness issue if a future extractor refinement starts treating noise as classes.

C6 is dead-code cleanup that happens to live inline.

## Result

### What changed

- **D1**: `VirtualCSSModulePlugin` tracks whether `load()` ever served the placeholder; in `generateBundle`, counts how many CSS assets received a successful replacement. If the placeholder was emitted but no asset matched and there is real extracted CSS to splice, calls `this.warn(...)` with a clear diagnostic naming the placeholder string and pointing at Vite's downstream CSS pipeline as the cause.
- **C7**: `master-css:extractor.configResolved` now blanks `options.include` only when the user did NOT pass an explicit array via `PluginOptions.extractor.include`. The default Vite-driven mode is preserved; users who explicitly seed extra paths are honoured.
- **C8**: `master-css:static.transform` filters by file extension allow-list (`html|js|jsx|ts|tsx|svelte|astro|vue|md|mdx|pug|php`) mirroring the extractor's default include glob. Vite query suffixes (`?import` / `?raw` / `?vue&...`) pass through; `.json`, binary assets, and own/3rd-party virtual modules are rejected.
- **C6**: extractor's `configPath` and `optionsPath` getters drop the dead `foundConfigPath` local and inline the `existsSync` check.

### What did NOT change

- `PluginOptions` (vite + extractor) — identical.
- Default behavior in the happy path — bundle output is byte-identical when no downstream CSS pipeline mutates the placeholder.
- Public event names, virtual module IDs, mode strings — identical.
- Vite **dev** path (`virtual-css-hmr.ts`) — untouched (covered by separate PR #434).

## Evidence

### Unit tests (new)

**`packages/vite/tests/plugins/virtual-css-module.test.ts`** — 5 cases for D1:
1. Replaces placeholder when present and does NOT warn (happy path).
2. Warns when placeholder was emitted but no CSS asset still contains it (the D1 regression).
3. Does NOT warn when virtual module was never imported.
4. Does NOT warn when extracted CSS is empty (no false alarms in config-only projects).
5. Only touches `type: 'asset'` chunks; `type: 'chunk'` JS bundles are left alone.

**`packages/vite/tests/modes/extract.test.ts`** — 9 cases for C7 + C8:
- C7 (4): default options blank `include`; user-supplied `include` preserved; explicit `include: []` is treated as "vite-driven mode"; `extractor: 'string-path'` does not crash the include guard.
- C8 (5): allows real source extensions; rejects `.json` / `.png` / `?url` / binary / own/3rd-party virtual modules; honours `?import`/`?raw`/`?vue` Vite query suffixes; always rejects own virtual master module id; always rejects `.css`.

### End-to-end smoke

**Baseline (`pnpm --filter master-css-vite-example build`)**:
- Output: `dist/assets/index-DwRtqU8J.css` 3.96 kB / gzip 1.75 kB.
- Real Master CSS rules present (`background-image:linear-gradient(120deg,#bd34fe 30%,#41d1ff)`, `background-clip:text`, `font-weight:500/900`).
- Slot placeholder leakage check: `grep -c "slot:0|virtual\\:master" dist/assets/*.css` → **0**.
- No D1 warn fired (correct — placeholder was successfully replaced).

**Hostile-CSS-pipeline reproduction (the D1 fix in action)**:

A PostCSS plugin was the easiest way to inject placeholder-mutating behaviour into Vite's CSS pipeline (any `.css` transform path would do — a custom vite plugin, a lightningcss config, a different minifier — would reproduce the same failure). Temporarily added a PostCSS plugin to `examples/vite/vite.config.ts` that rewrites `\:` → `_` in selectors of rules containing `virtual` (a deliberate-but-realistic mutation of the placeholder). Re-built:

```
vite v6.3.5 building for production...
✓ 7 modules transformed.
[plugin master-css:static:virtual-css-module:build] [master-css.vite] Could not splice
extracted CSS into any bundle asset. The placeholder "#virtual\:master\.css{--slot:0}"
was emitted but no CSS chunk in the final bundle still contained it — Vite's downstream
CSS pipeline (a PostCSS plugin in your vite config, the bundler's CSS minifier, etc.)
most likely rewrote or dropped it. The output will be missing all extracted classes.
dist/assets/index-CcGk2O1h.css  2.98 kB │ gzip: 1.29 kB
```

Bundle CSS shrunk from 3.96 kB → 2.98 kB. The **missing 1 kB IS the extracted classes** that silently went missing in the pre-fix world. The new warn names the failure precisely. After capturing the log, `examples/vite/vite.config.ts` was reverted.

**Vite dev server (`examples/vite` extract mode)**:
- Started, opened in agent-browser. Page renders correctly: gradient "Vite + Master CSS" title, logos, button.

### Aggregate test status

| Package | Before | After |
|---|---:|---:|
| `@master/css-extractor` | 25 / 25 | 25 / 25 |
| `@master/css.vite` | 11 / 11 | **25 / 25** |
| **Total relevant** | 36 | **50 / 50 pass** |

`type-check` + `lint` clean for the two changed packages.

## Test plan

- [x] `pnpm --filter @master/css.vite test --run` — 25/25 pass
- [x] `pnpm --filter @master/css-extractor test --run` — 25/25 pass
- [x] `pnpm --filter @master/css.vite type-check` — clean
- [x] `pnpm --filter @master/css.vite lint` — clean
- [x] `examples/vite` build (baseline) → 3.96 kB CSS, no slot leakage, no warn
- [x] `examples/vite` build (hostile PostCSS) → D1 warn fires loudly with precise diagnostic, output CSS confirmed degraded by exactly the missing 1 kB
- [x] `examples/vite` (extract mode) dev server → opens, renders correctly in agent-browser
