### PR TITLE
Fix(Integration): Load browser manifest via fetch to avoid import attributes

### DIFF
--- a/packages/integration/src/manifest-facade.ts
+++ b/packages/integration/src/manifest-facade.ts
@@ -41,11 +41,18 @@ export function toManifestPreloadLinkTag(href: string) {
 }
 
 export function toBrowserManifestFacadeModule(urlExpression: string) {
+  // Load the manifest with `fetch` rather than a JSON import attribute
+  // (`import(url, { with: { type: 'json' } })`). Import attributes are only
+  // supported in Safari 17.2+, Chrome 123+, and Firefox 130+; on older engines
+  // — notably all iOS 15/16 (Safari < 17.2) — evaluating that dynamic import,
+  // even inside `new Function`, throws `SyntaxError: import call expects exactly
+  // one argument` while the entry module is being evaluated, so the whole app
+  // fails to bootstrap and renders blank with no obvious console error. `fetch`
+  // is universally supported and needs no bundler-hiding indirection.
   return [
     `const masterCSSManifestURL = ${urlExpression};`,
-    `const loadMasterCSSManifestModule = new Function('specifier', "return import(specifier, { with: { type: 'json' } })");`,
-    `const masterCSSManifestModule = await loadMasterCSSManifestModule(typeof masterCSSManifestURL === 'string' ? masterCSSManifestURL : masterCSSManifestURL.href);`,
-    `export default masterCSSManifestModule.default;`,
+    `const masterCSSManifestResponse = await fetch(typeof masterCSSManifestURL === 'string' ? masterCSSManifestURL : masterCSSManifestURL.href);`,
+    `export default await masterCSSManifestResponse.json();`,
     ``
   ].join('\n')
 }
@@ -89,16 +96,18 @@ export function toUniversalManifestFacadeModule(urlExpression: string) {
     `    throw lastError;`,
     `}`,
     ``,
-    `async function loadMasterCSSManifestFromImport(url) {`,
+    `async function loadMasterCSSManifestFromFetch(url) {`,
     `    const specifier = typeof url === 'string' ? url : url.href;`,
-    `    const load = new Function('specifier', "return import(specifier, { with: { type: 'json' } })");`,
-    `    const manifestModule = await load(specifier);`,
-    `    return manifestModule.default;`,
+    `    const response = await fetch(specifier);`,
+    `    return response.json();`,
     `}`,
     ``,
+    // Browsers use `fetch`; only the Node branch keeps the JSON import attribute.
+    // See `toBrowserManifestFacadeModule` for why import attributes cannot be used
+    // on the browser (they break Safari < 17.2 / iOS 15-16 at parse time).
     `export default typeof window === 'undefined'`,
     `    ? await loadMasterCSSManifestFromFile(masterCSSManifestURL)`,
-    `    : await loadMasterCSSManifestFromImport(masterCSSManifestURL);`,
+    `    : await loadMasterCSSManifestFromFetch(masterCSSManifestURL);`,
     ``
   ].join('\n')
 }

--- a/packages/integration/tests/module.test.ts
+++ b/packages/integration/tests/module.test.ts
@@ -15,6 +15,7 @@ import {
   toManifestJSON,
   toManifestPreloadLinkAttrs,
   toManifestPreloadLinkTag,
+  toBrowserManifestFacadeModule,
   toEmittedGlobalsModule,
   toUniversalManifestFacadeModule
 } from '../src/module'
@@ -69,9 +70,24 @@ describe('@master/css-integration module helpers', () => {
     expect(source).toContain(`join(process.cwd(), '.next', value.slice('/_next/'.length))`)
     expect(source).toContain(`join(process.cwd(), '.next', 'dev', value.slice('/_next/'.length))`)
     expect(source).toContain('for (const file of files)')
+    // Node branch keeps the JSON import attribute (Node supports it).
     expect(source).toContain(`return import(specifier, options)`)
     expect(source).toContain(`with: { type: 'json' }`)
-    expect(source).not.toContain('fetch(')
+    // Browser branch loads via fetch; import attributes break Safari < 17.2 (iOS 15/16).
+    expect(source).toContain('await fetch(specifier)')
+    expect(source).toContain(': await loadMasterCSSManifestFromFetch(masterCSSManifestURL)')
     expect(source).not.toContain('readFile')
+  })
+
+  it('builds a browser manifest facade that avoids import attributes', () => {
+    const source = toBrowserManifestFacadeModule('new URL("./master-css-manifest.json", import.meta.url)')
+
+    // Must load the manifest with fetch, never `import(url, { with: { type: 'json' } })`.
+    // Import attributes are a SyntaxError on Safari < 17.2 (all iOS 15/16), and evaluating
+    // them — even inside `new Function` — breaks the entire app at bootstrap with a blank page.
+    expect(source).toContain('await fetch(')
+    expect(source).toContain('.json()')
+    expect(source).not.toContain('with: { type:')
+    expect(source).not.toContain('new Function')
   })
 })


### PR DESCRIPTION
## Problem

Apps using Master CSS in runtime mode render a **blank page with no obvious console error on Safari < 17.2 — which includes every iOS 15 and iOS 16 device** (iOS 16 tops out at 16.7).

The browser manifest facades generate a loader like:

```js
const loadMasterCSSManifestModule = new Function('specifier', "return import(specifier, { with: { type: 'json' } })");
```

JSON **import attributes** (`import(url, { with: { type: 'json' } })`) are only supported in **Safari 17.2+, Chrome 123+, Firefox 130+**. On older engines, evaluating that dynamic import — even inside `new Function` — throws:

```
SyntaxError: import call expects exactly one argument.
```

Because the manifest facade runs at the **top level of the app entry module**, this aborts entry evaluation, so the framework never mounts and the page stays blank. There's no clear console error, which makes it very hard to diagnose.

It's also invisible to build-time checks: the syntax lives inside a `new Function` **string**, so esbuild/Rollup/Vite target scans never parse or flag it. (I spent a while scanning bundles with `--target=safari16` and they all reported "clean" for exactly this reason.)

## Fix

Load the manifest with `fetch(...).then(r => r.json())` in the two **browser** facades:
- `toBrowserManifestFacadeModule`
- the browser branch of `toUniversalManifestFacadeModule` (renamed `loadMasterCSSManifestFromImport` → `loadMasterCSSManifestFromFetch`)

`fetch` is universally supported and needs no `new Function` bundler-hiding indirection. **The Node facades (`toNodeManifestFacadeModule` and the `loadMasterCSSManifestFromFile` branch) keep the JSON import attribute**, since Node supports it and those paths only run when `typeof window === 'undefined'`.

## Verification

- Repro + fix confirmed on a real **iOS 15.5 Safari simulator** (WebKit): before, the entry chunk fails to evaluate and the app is blank; after, it bootstraps normally.
- `packages/integration` tests updated + a browser-facade regression test added; full suite passes (12/12), type-check and lint clean.

## Notes

- The manifest preload tag is still emitted as `rel="modulepreload" as="json"` (hardcoded across the vite/webpack/nuxt/astro integrations). It's harmless with a `fetch` load but slightly inconsistent; happy to follow up separately to switch it to `rel="preload" as="fetch"` if you'd prefer.